### PR TITLE
Fix shadowing warnings

### DIFF
--- a/examples/dump_video.c
+++ b/examples/dump_video.c
@@ -130,19 +130,19 @@ static void video_write(void) {
 }
 
 /* dump the daala comment header */
-static int dump_comments(daala_comment *dc) {
+static int dump_comments(daala_comment *comment) {
   int i;
   int len;
   FILE *out;
   out = stderr;
-  fprintf(out, "Encoded by %s\n", dc->vendor);
-  if (dc->comments) {
+  fprintf(out, "Encoded by %s\n", comment->vendor);
+  if (comment->comments) {
     fprintf(out, "daala comment header:\n");
-    for (i = 0; i < dc->comments; i++) {
-      if (dc->user_comments[i]) {
-        len = dc->comment_lengths[i] < INT_MAX ?
-         dc->comment_lengths[i] : INT_MAX;
-        fprintf(out, "\t%.*s\n", len, dc->user_comments[i]);
+    for (i = 0; i < comment->comments; i++) {
+      if (comment->user_comments[i]) {
+        len = comment->comment_lengths[i] < INT_MAX ?
+         comment->comment_lengths[i] : INT_MAX;
+        fprintf(out, "\t%.*s\n", len, comment->user_comments[i]);
       }
     }
   }
@@ -304,8 +304,7 @@ int main(int argc, char *argv[]) {
       queue_page(&og); /* demux into the appropriate stream */
     }
     else {
-      int ret = buffer_data(infile, &oy); /* someone needs more data */
-      if (ret == 0) {
+      if (buffer_data(infile, &oy) == 0) { /* someone needs more data */
         fprintf(stderr, "End of file while searching for codec headers.\n");
         exit(1);
       }

--- a/src/dct.c
+++ b/src/dct.c
@@ -29,6 +29,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include "block_size.h"
 #include "dct.h"
 
+/*Ignore shadowed variables in macros.*/
+#pragma GCC diagnostic ignored "-Wshadow"
+
 /*Making function pointer tables at least one entry
    longer than needed makes it highly likely that an
    off-by-one will result in a null-pointer rather than

--- a/src/encode.c
+++ b/src/encode.c
@@ -1353,7 +1353,6 @@ static void od_encode_mvs(daala_enc_ctx *enc) {
         }
       }
       else if (vx < 2 || vx > nhmvbs - 2) {
-        od_mv_grid_pt *other;
         if ((vy == 3 && grid[vy - 1][vx == 1 ? vx - 1 : vx + 1].valid)
          || (vy == nvmvbs - 3
           && grid[vy + 1][vx == 1 ? vx - 1 : vx + 1].valid)) {
@@ -1527,12 +1526,12 @@ static void od_encode_residual(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
         xdec = state->io_imgs[OD_FRAME_INPUT].planes[pli].xdec;
         ydec = state->io_imgs[OD_FRAME_INPUT].planes[pli].ydec;
         if (!OD_DISABLE_HAAR_DC && mbctx->is_keyframe) {
-          int w;
-          w = enc->state.frame_width;
+          int width;
+          width = enc->state.frame_width;
           if (rdo_only) {
             for (i = 0; i < OD_BSIZE_MAX; i++) {
               for (j = 0; j < OD_BSIZE_MAX; j++) {
-                c_orig[i*OD_BSIZE_MAX + j] = mbctx->c[(OD_BSIZE_MAX*sby + i)*w
+                c_orig[i*OD_BSIZE_MAX + j] = mbctx->c[(OD_BSIZE_MAX*sby + i)*width
                  + OD_BSIZE_MAX*sbx + j];
               }
             }
@@ -1545,7 +1544,7 @@ static void od_encode_residual(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
             od_encode_rollback(enc, &buf);
             for (i = 0; i < OD_BSIZE_MAX; i++) {
               for (j = 0; j < OD_BSIZE_MAX; j++) {
-                mbctx->c[(OD_BSIZE_MAX*sby + i)*w + OD_BSIZE_MAX*sbx + j] =
+                mbctx->c[(OD_BSIZE_MAX*sby + i)*width + OD_BSIZE_MAX*sbx + j] =
                  c_orig[i*OD_BSIZE_MAX + j];
               }
             }

--- a/src/entenc.c
+++ b/src/entenc.c
@@ -538,7 +538,7 @@ unsigned char *od_ec_enc_done(od_ec_enc *enc, ogg_uint32_t *nbytes) {
   offs = enc->offs;
   buf = enc->precarry_buf;
   if (s > 0) {
-    unsigned m;
+    unsigned n;
     storage = enc->precarry_storage;
     if (offs + ((s + 7) >> 3) > storage) {
       storage = storage*2 + ((s + 7) >> 3);
@@ -550,14 +550,14 @@ unsigned char *od_ec_enc_done(od_ec_enc *enc, ogg_uint32_t *nbytes) {
       enc->precarry_buf = buf;
       enc->precarry_storage = storage;
     }
-    m = (1 << (c + 16)) - 1;
+    n = (1 << (c + 16)) - 1;
     do {
       OD_ASSERT(offs < storage);
       buf[offs++] = (ogg_uint16_t)(e >> (c + 16));
-      e &= m;
+      e &= n;
       s -= 8;
       c -= 8;
-      m >>= 8;
+      n >>= 8;
     }
     while (s > 0);
   }

--- a/src/tests/ectest.c
+++ b/src/tests/ectest.c
@@ -252,14 +252,14 @@ int main(int _argc,char **_argv){
   /*Test compatibility between multiple different encode/decode routines.*/
   for(i=0;i<409600;i++){
     unsigned *fz;
-    unsigned *ftb;
+    unsigned *ftbs;
     unsigned *data;
     unsigned *tell;
     unsigned *enc_method;
     int       j;
     sz=rand()/((RAND_MAX>>(rand()%9U))+1U);
     fz=(unsigned *)malloc(sz*sizeof(*fz));
-    ftb=(unsigned *)malloc(sz*sizeof(*ftb));
+    ftbs=(unsigned *)malloc(sz*sizeof(*ftbs));
     data=(unsigned *)malloc(sz*sizeof(*data));
     tell=(unsigned *)malloc((sz+1)*sizeof(*tell));
     enc_method=(unsigned *)malloc(sz*sizeof(*enc_method));
@@ -267,20 +267,20 @@ int main(int _argc,char **_argv){
     tell[0]=od_ec_enc_tell_frac(&enc);
     for(j=0;j<sz;j++){
       data[j]=rand()/((RAND_MAX>>1)+1);
-      ftb[j]=(rand()%15)+1;
-      fz[j]=rand()%32766>>15-ftb[j];
+      ftbs[j]=(rand()%15)+1;
+      fz[j]=rand()%32766>>15-ftbs[j];
       fz[j]=OD_MAXI(fz[j],1);
       enc_method[j]=rand()&1;
       switch(enc_method[j]){
         case 0:{
-          if(rand()&1)od_ec_encode_bool_q15(&enc,data[j],fz[j]<<15-ftb[j]);
-          else od_ec_encode_bool(&enc,data[j],fz[j]<<15-ftb[j],32768);
+          if(rand()&1)od_ec_encode_bool_q15(&enc,data[j],fz[j]<<15-ftbs[j]);
+          else od_ec_encode_bool(&enc,data[j],fz[j]<<15-ftbs[j],32768);
         }break;
         case 1:{
           ogg_uint16_t cdf[2];
           cdf[0]=fz[j];
-          cdf[1]=1U<<ftb[j];
-          od_ec_encode_cdf_unscaled_dyadic(&enc,data[j],cdf,2,ftb[j]);
+          cdf[1]=1U<<ftbs[j];
+          od_ec_encode_cdf_unscaled_dyadic(&enc,data[j],cdf,2,ftbs[j]);
         }break;
       }
       tell[j+1]=od_ec_enc_tell_frac(&enc);
@@ -304,20 +304,20 @@ int main(int _argc,char **_argv){
       dec_method=rand()&1;
       switch(dec_method){
         case 0:{
-          if(rand()&1)sym=od_ec_decode_bool_q15(&dec,fz[j]<<15-ftb[j]);
-          else sym=od_ec_decode_bool(&dec,fz[j]<<15-ftb[j],32768);
+          if(rand()&1)sym=od_ec_decode_bool_q15(&dec,fz[j]<<15-ftbs[j]);
+          else sym=od_ec_decode_bool(&dec,fz[j]<<15-ftbs[j],32768);
         }break;
         case 1:{
           ogg_uint16_t cdf[2];
           cdf[0]=fz[j];
-          cdf[1]=1U<<ftb[j];
-          sym=od_ec_decode_cdf_unscaled_dyadic(&dec,cdf,2,ftb[j]);
+          cdf[1]=1U<<ftbs[j];
+          sym=od_ec_decode_cdf_unscaled_dyadic(&dec,cdf,2,ftbs[j]);
         }break;
       }
       if(sym!=data[j]){
         fprintf(stderr,"Decoded %i instead of %i with fz=%i and ftb=%i "
          "at position %i of %i (Random seed: %u).\n",
-         sym,data[j],fz[j],ftb[j],j,sz,seed);
+         sym,data[j],fz[j],ftbs[j],j,sz,seed);
         fprintf(stderr,"Encoding method: %i, decoding method: %i\n",
          enc_method[j],dec_method);
         ret=EXIT_FAILURE;
@@ -332,7 +332,7 @@ int main(int _argc,char **_argv){
     free(enc_method);
     free(tell);
     free(data);
-    free(ftb);
+    free(ftbs);
     free(fz);
   }
   od_ec_enc_reset(&enc);


### PR DESCRIPTION
Fixes #75. For `src/dct.c` I disabled `-Wshadow`, since all the warnings were variables shadowed in expanded macros.