### PR TITLE
Ensure -mavx2 is added to CFLAGS when AVX2 intrinsics enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,6 +223,7 @@ AS_IF([test "$enable_asm" = "yes" -a "$cpu_x86" = "true"], [
          enable_avx2_intrinsics=yes
          AC_DEFINE([OD_AVX2_INTRINSICS], [1],
           [Enable AVX2 intrinsics optimisations])
+         TMP_CFLAGS="$CFLAGS"
        ], [enable_avx2_intrinsics=no]
       )
      ], [enable_sse41_intrinsics=no]


### PR DESCRIPTION
This should fix #82.