### PR TITLE
Faster block copy functions.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ lib_LTLIBRARIES = src/libdaalabase.la src/libdaaladec.la src/libdaalaenc.la
 AM_CPPFLAGS = -I$(srcdir)/include
 
 noinst_HEADERS = \
+	src/util.h \
 	src/adapt.h \
 	src/block_size.h \
 	src/block_size_enc.h \
@@ -72,6 +73,7 @@ src_libdaalabase_la_LDFLAGS = -no-undefined \
 src_libdaalabase_la_LDFLAGS +=
 src_libdaalabase_la_SOURCES = \
 	src/accounting.c \
+	src/util.c \
 	src/adapt.c \
 	src/entcode.c \
 	src/entdec.c \
@@ -100,6 +102,7 @@ src_libdaalabase_la_SOURCES = \
 	$(src_dct_SOURCES)
 if ENABLE_X86ASM
 src_libdaalabase_la_SOURCES += \
+	src/x86/x86util.c \
 	src/x86/sse2mc.c \
 	src/x86/x86state.c
 endif
@@ -331,6 +334,7 @@ tools_upsample_SOURCES = \
 	tools/upsample.c
 if ENABLE_X86ASM
 tools_upsample_SOURCES += \
+	src/x86/c86util.c \
 	src/x86/sse2mc.c \
 	src/x86/x86state.c
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@ lib_LTLIBRARIES = src/libdaalabase.la src/libdaaladec.la src/libdaalaenc.la
 AM_CPPFLAGS = -I$(srcdir)/include
 
 noinst_HEADERS = \
-	src/util.h \
 	src/adapt.h \
 	src/block_size.h \
 	src/block_size_enc.h \
@@ -34,6 +33,7 @@ noinst_HEADERS = \
 	src/quantizer.h \
 	src/state.h \
 	src/tf.h \
+	src/util.h \
 	src/zigzag.h \
 	src/accounting.h \
 	src/x86/cpu.h \
@@ -73,7 +73,6 @@ src_libdaalabase_la_LDFLAGS = -no-undefined \
 src_libdaalabase_la_LDFLAGS +=
 src_libdaalabase_la_SOURCES = \
 	src/accounting.c \
-	src/util.c \
 	src/adapt.c \
 	src/entcode.c \
 	src/entdec.c \
@@ -94,6 +93,7 @@ src_libdaalabase_la_SOURCES = \
 	src/state.c \
 	src/switch_table.c \
 	src/tf.c \
+	src/util.c \
 	src/zigzag4.c \
 	src/zigzag8.c \
 	src/zigzag16.c \
@@ -102,8 +102,8 @@ src_libdaalabase_la_SOURCES = \
 	$(src_dct_SOURCES)
 if ENABLE_X86ASM
 src_libdaalabase_la_SOURCES += \
-	src/x86/sse2util.c \
 	src/x86/sse2mc.c \
+	src/x86/sse2util.c \
 	src/x86/x86state.c
 endif
 
@@ -334,8 +334,8 @@ tools_upsample_SOURCES = \
 	tools/upsample.c
 if ENABLE_X86ASM
 tools_upsample_SOURCES += \
-	src/x86/sse2util.c \
 	src/x86/sse2mc.c \
+	src/x86/sse2util.c \
 	src/x86/x86state.c
 endif
 tools_upsample_CFLAGS = $(THEORA_CFLAGS) $(OGG_CFLAGS) $(PNG_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -102,7 +102,7 @@ src_libdaalabase_la_SOURCES = \
 	$(src_dct_SOURCES)
 if ENABLE_X86ASM
 src_libdaalabase_la_SOURCES += \
-	src/x86/x86util.c \
+	src/x86/sse2util.c \
 	src/x86/sse2mc.c \
 	src/x86/x86state.c
 endif
@@ -334,7 +334,7 @@ tools_upsample_SOURCES = \
 	tools/upsample.c
 if ENABLE_X86ASM
 tools_upsample_SOURCES += \
-	src/x86/c86util.c \
+	src/x86/sse2util.c \
 	src/x86/sse2mc.c \
 	src/x86/x86state.c
 endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -64,6 +64,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 /*Smallest motion compensation partition sizes are 4x4.*/
 # define OD_LOG_MVBSIZE_MIN (2)
 # define OD_MVBSIZE_MIN (1 << OD_LOG_MVBSIZE_MIN)
+
+/*The log of the maximum length of the side of a block that
+   has optimized copy variants.*/
+# define OD_LOG_COPYBSIZE_MAX (6)
+
 /*log(2) of the spacing between level-0 MV grid points.*/
 # define OD_LOG_MVB_DELTA0 (OD_LOG_MVBSIZE_MAX - OD_LOG_MVBSIZE_MIN)
 /*The number of different MV block sizes.*/

--- a/src/mc.c
+++ b/src/mc.c
@@ -196,18 +196,7 @@ void od_mc_predict1fmv8_c(unsigned char *dst, const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    if (yblk_sz == xblk_sz && yblk_sz == 16) {
-      od_copy_16x16(dst_p, xblk_sz, src_p, systride);
-    }
-    else if (yblk_sz == xblk_sz && yblk_sz == 32) {
-      od_copy_32x32(dst_p, xblk_sz, src_p, systride);
-    }
-    else if (yblk_sz == xblk_sz && yblk_sz == 64) {
-      od_copy_64x64(dst_p, xblk_sz, src_p, systride);
-    }
-    else {
-      od_copy_nxm(dst_p, xblk_sz, src_p, systride, xblk_sz, yblk_sz);
-    }
+    od_copy_log_nxm(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
   }
 }
 

--- a/src/mc.c
+++ b/src/mc.c
@@ -196,7 +196,7 @@ void od_mc_predict1fmv8_c(unsigned char *dst, const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    od_copy_log_nxm(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
+    od_copy_nxm_c(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
   }
 }
 

--- a/src/mc.c
+++ b/src/mc.c
@@ -196,13 +196,13 @@ void od_mc_predict1fmv8_c(unsigned char *dst, const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    if (yblk_sz == xblk_sz && log_yblk_sz == 16) {
+    if (yblk_sz == xblk_sz && yblk_sz == 16) {
       od_copy_16x16(dst_p, xblk_sz, src_p, systride);
     }
-    else if (yblk_sz == xblk_sz && log_yblk_sz == 32) {
+    else if (yblk_sz == xblk_sz && yblk_sz == 32) {
       od_copy_32x32(dst_p, xblk_sz, src_p, systride);
     }
-    else if (yblk_sz == xblk_sz && log_yblk_sz == 64) {
+    else if (yblk_sz == xblk_sz && yblk_sz == 64) {
       od_copy_64x64(dst_p, xblk_sz, src_p, systride);
     }
     else {

--- a/src/mc.c
+++ b/src/mc.c
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include "logging.h"
 #include "mc.h"
 #include "state.h"
+#include "util.h"
 
 /*Motion compensation routines shared between the encoder and decoder.*/
 
@@ -195,10 +196,17 @@ void od_mc_predict1fmv8_c(unsigned char *dst, const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    for (j = 0; j < yblk_sz; j++) {
-      OD_COPY(dst_p, src_p, xblk_sz);
-      src_p += systride;
-      dst_p += xblk_sz;
+    if (yblk_sz == xblk_sz && log_yblk_sz == 16) {
+      od_copy_16x16(dst_p, xblk_sz, src_p, systride);
+    }
+    else if (yblk_sz == xblk_sz && log_yblk_sz == 32) {
+      od_copy_32x32(dst_p, xblk_sz, src_p, systride);
+    }
+    else if (yblk_sz == xblk_sz && log_yblk_sz == 64) {
+      od_copy_64x64(dst_p, xblk_sz, src_p, systride);
+    }
+    else {
+      od_copy_nxm(dst_p, xblk_sz, src_p, systride, xblk_sz, yblk_sz);
     }
   }
 }

--- a/src/mc.c
+++ b/src/mc.c
@@ -91,8 +91,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
   For now, we add the extra padding, but we should eventually add
    special-casing to the code to avoid the additional ~useless buffer
    overhead. */
-void od_mc_predict1fmv8_c(unsigned char *dst, const unsigned char *src,
- int systride, int32_t mvx, int32_t mvy,
+void od_mc_predict1fmv8_c(od_state *state, unsigned char *dst,
+ const unsigned char *src, int systride, int32_t mvx, int32_t mvy,
  int log_xblk_sz, int log_yblk_sz) {
   int mvxf;
   int mvyf;
@@ -196,7 +196,8 @@ void od_mc_predict1fmv8_c(unsigned char *dst, const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    od_copy_nxm_c(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
+    OD_ASSERT(log_xblk_sz == log_yblk_sz);
+    (*state->opt_vtbl.od_copy_nxn[log_xblk_sz])(dst_p, xblk_sz, src_p, systride);
   }
 }
 
@@ -205,7 +206,7 @@ static void od_mc_predict1fmv(od_state *state, unsigned char *dst,
  int log_xblk_sz, int log_yblk_sz) {
   OD_ASSERT(OD_SUBPEL_TOP_APRON_SZ <= OD_RESAMPLE_PADDING
    && OD_SUBPEL_BOTTOM_APRON_SZ <= OD_RESAMPLE_PADDING);
-  (*state->opt_vtbl.mc_predict1fmv)(dst, src, systride, mvx, mvy,
+  (*state->opt_vtbl.mc_predict1fmv)(state, dst, src, systride, mvx, mvy,
    log_xblk_sz, log_yblk_sz);
 }
 

--- a/src/mcenc.c
+++ b/src/mcenc.c
@@ -2308,7 +2308,7 @@ static int32_t od_mv_est_bma_sad(od_mv_est_ctx *est,
        + (by >> iplane->ydec)*iplane->ystride
        + (bx >> iplane->xdec)*iplane->xstride;
       (*state->opt_vtbl.mc_predict1fmv)
-       (state->mc_buf[4], ref_img, iplane->ystride,
+       (state, state->mc_buf[4], ref_img, iplane->ystride,
        mvx << (3 - iplane->xdec), mvy << (3 - iplane->ydec),
        log_mvb_sz + OD_LOG_MVBSIZE_MIN - iplane->xdec,
        log_mvb_sz + OD_LOG_MVBSIZE_MIN - iplane->ydec);

--- a/src/state.c
+++ b/src/state.c
@@ -197,8 +197,7 @@ void od_state_opt_vtbl_init_c(od_state *state) {
   state->opt_vtbl.mc_blend_multi = od_mc_blend_multi8_c;
   state->opt_vtbl.mc_blend_multi_split = od_mc_blend_multi_split8_c;
   state->opt_vtbl.restore_fpu = od_restore_fpu_c;
-  state->opt_vtbl.od_copy_nxm = od_copy_nxm_c;
-  state->opt_vtbl.od_copy_nxn = od_copy_nxn_c;
+  OD_COPY(state->opt_vtbl.od_copy_nxn, OD_COPY_NXN_C, OD_LOG_COPYBSIZE_MAX + 1);
   OD_COPY(state->opt_vtbl.fdct_2d, OD_FDCT_2D_C, OD_NBSIZES + 1);
   OD_COPY(state->opt_vtbl.idct_2d, OD_IDCT_2D_C, OD_NBSIZES + 1);
 }

--- a/src/state.c
+++ b/src/state.c
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include <stdlib.h>
 #include <string.h>
 #include "state.h"
+#include "util.h"
 #if defined(OD_X86ASM)
 # include "x86/x86int.h"
 #endif
@@ -196,6 +197,8 @@ void od_state_opt_vtbl_init_c(od_state *state) {
   state->opt_vtbl.mc_blend_multi = od_mc_blend_multi8_c;
   state->opt_vtbl.mc_blend_multi_split = od_mc_blend_multi_split8_c;
   state->opt_vtbl.restore_fpu = od_restore_fpu_c;
+  state->opt_vtbl.od_copy_nxm = od_copy_nxm_c;
+  state->opt_vtbl.od_copy_nxn = od_copy_nxn_c;
   OD_COPY(state->opt_vtbl.fdct_2d, OD_FDCT_2D_C, OD_NBSIZES + 1);
   OD_COPY(state->opt_vtbl.idct_2d, OD_IDCT_2D_C, OD_NBSIZES + 1);
 }

--- a/src/state.h
+++ b/src/state.h
@@ -94,7 +94,7 @@ extern const int *const OD_VERT_SETUP_DY[4][4];
  /OD_PADDING_ALIGN*OD_PADDING_ALIGN)
 
 /*The shared (encoder and decoder) functions that have accelerated variants.*/
-struct od_state_opt_vtbl {
+struct od_state_opt_vtbl{
   void (*mc_predict1fmv)(unsigned char *_dst, const unsigned char *_src,
    int _systride, int32_t _mvx, int32_t _mvy,
    int _log_xblk_sz, int _log_yblk_sz);

--- a/src/state.h
+++ b/src/state.h
@@ -38,6 +38,7 @@ typedef struct od_pvq_codeword_ctx od_pvq_codeword_ctx;
 # include "pvq.h"
 # include "adapt.h"
 # include "generic_code.h"
+# include "util.h"
 #include "intra.h"
 
 extern const od_coeff OD_DC_RES[3];
@@ -95,8 +96,8 @@ extern const int *const OD_VERT_SETUP_DY[4][4];
 
 /*The shared (encoder and decoder) functions that have accelerated variants.*/
 struct od_state_opt_vtbl{
-  void (*mc_predict1fmv)(unsigned char *_dst, const unsigned char *_src,
-   int _systride, int32_t _mvx, int32_t _mvy,
+  void (*mc_predict1fmv)(od_state *state, unsigned char *_dst,
+   const unsigned char *_src, int _systride, int32_t _mvx, int32_t _mvy,
    int _log_xblk_sz, int _log_yblk_sz);
   void (*mc_blend_full)(unsigned char *_dst, int _dystride,
    const unsigned char *_src[4], int _log_xblk_sz, int _log_yblk_sz);
@@ -111,10 +112,7 @@ struct od_state_opt_vtbl{
   void (*restore_fpu)(void);
   od_dct_func_2d fdct_2d[OD_NBSIZES + 1];
   od_dct_func_2d idct_2d[OD_NBSIZES + 1];
-  void (*od_copy_nxn)(unsigned char *_dst, int _dstride,
-   const unsigned char *_src, int _sstride, int _log_n);
-  void (*od_copy_nxm)(unsigned char *_dst, int _dstride,
-   const unsigned char *_src, int _sstride, int _log_n, int _log_m);
+  od_copy_nxn_func od_copy_nxn[OD_LOG_COPYBSIZE_MAX + 1];
 };
 
 # if defined(OD_DUMP_IMAGES) || defined(OD_DUMP_RECONS)
@@ -265,8 +263,8 @@ int od_state_dump_img(od_state *state, od_img *img, const char *tag);
 /*Shared accelerated functions.*/
 
 /*Default pure-C implementations.*/
-void od_mc_predict1fmv8_c(unsigned char *_dst, const unsigned char *_src,
- int _systride, int32_t _mvx, int32_t _mvy,
+void od_mc_predict1fmv8_c(od_state *state, unsigned char *_dst,
+ const unsigned char *_src, int _systride, int32_t _mvx, int32_t _mvy,
  int _log_xblk_sz, int _log_yblk_sz);
 void od_mc_blend_full8_c(unsigned char *_dst, int _dystride,
  const unsigned char *_src[4], int _log_xblk_sz, int _log_yblk_sz);

--- a/src/state.h
+++ b/src/state.h
@@ -94,7 +94,7 @@ extern const int *const OD_VERT_SETUP_DY[4][4];
  /OD_PADDING_ALIGN*OD_PADDING_ALIGN)
 
 /*The shared (encoder and decoder) functions that have accelerated variants.*/
-struct od_state_opt_vtbl{
+struct od_state_opt_vtbl {
   void (*mc_predict1fmv)(unsigned char *_dst, const unsigned char *_src,
    int _systride, int32_t _mvx, int32_t _mvy,
    int _log_xblk_sz, int _log_yblk_sz);
@@ -111,6 +111,10 @@ struct od_state_opt_vtbl{
   void (*restore_fpu)(void);
   od_dct_func_2d fdct_2d[OD_NBSIZES + 1];
   od_dct_func_2d idct_2d[OD_NBSIZES + 1];
+  void (*od_copy_nxn)(unsigned char *_dst, int _dstride,
+   const unsigned char *_src, int _sstride, int _log_n);
+  void (*od_copy_nxm)(unsigned char *_dst, int _dstride,
+   const unsigned char *_src, int _sstride, int _log_n, int _log_m);
 };
 
 # if defined(OD_DUMP_IMAGES) || defined(OD_DUMP_RECONS)

--- a/src/util.c
+++ b/src/util.c
@@ -92,11 +92,25 @@ void od_copy_64x64(unsigned char *_dst, int _dstride,
 #endif
 }
 
-void od_copy_nxm(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int n, int m) {
+void od_copy_log_nxm(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int _log_n, int _log_m) {
+  if (_log_n == _log_m) {
+    if (_log_n == 4) {
+      od_copy_16x16(_dst, _dstride, _src, _sstride);
+      return;
+    }
+    else if (_log_n == 5) {
+      od_copy_32x32(_dst, _dstride, _src, _sstride);
+      return;
+    }
+    else if (_log_n == 6) {
+      od_copy_64x64(_dst, _dstride, _src, _sstride);
+      return;
+    }
+  }
   int j;
-  for (j = 0; j < m; j++) {
-    OD_COPY(_dst, _src, n);
+  for (j = 0; j < 1 << _log_m; j++) {
+    OD_COPY(_dst, _src, 1 << _log_n);
     _dst += _dstride;
     _src += _sstride;
   }

--- a/src/util.c
+++ b/src/util.c
@@ -95,7 +95,7 @@ void od_copy_log_nxn(unsigned char *_dst, int _dstride,
     od_copy_32x32,
     od_copy_64x64
   };
-  OD_ASSERT(_log_n >= OD_LOG_BSIZE0 || _log_n <= 6);
+  OD_ASSERT(_log_n > 0 || _log_n <= 6);
   (*VTBL[_log_n])(_dst, _dstride, _src, _sstride);
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,100 @@
+/*Daala video codec
+Copyright (c) 2013 Daala project contributors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdlib.h>
+
+#include "internal.h"
+#include "util.h"
+#include "x86/x86int.h"
+
+void od_copy_16x16_c(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride) {
+  int y;
+  for (y = 0; y < 16; y++) {
+    memcpy(_dst, _src, 16);
+    _dst += _dstride;
+    _src += _sstride;
+  }
+}
+
+void od_copy_32x32_c(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride) {
+  int y;
+  for (y = 0; y < 32; y++) {
+    memcpy(_dst, _src, 32);
+    _dst += _dstride;
+    _src += _sstride;
+  }
+}
+
+void od_copy_64x64_c(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride) {
+  int y;
+  for (y = 0; y < 64; y++) {
+    memcpy(_dst, _src, 64);
+    _dst += _dstride;
+    _src += _sstride;
+  }
+}
+
+void od_copy_16x16(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride) {
+#if defined(OD_SSE2_INTRINSICS)
+  od_copy_16x16_sse2(_dst, _dstride, _src, _sstride);
+#elif
+  od_copy_16x16_c(_dst, _dstride, _src, _sstride);
+#endif
+}
+
+void od_copy_32x32(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride) {
+#if defined(OD_SSE2_INTRINSICS)
+  od_copy_32x32_sse2(_dst, _dstride, _src, _sstride);
+#elif
+  od_copy_32x32_c(_dst, _dstride, _src, _sstride);
+#endif
+}
+
+void od_copy_64x64(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride) {
+#if defined(OD_SSE2_INTRINSICS)
+  od_copy_64x64_sse2(_dst, _dstride, _src, _sstride);
+#elif
+  od_copy_64x64_c(_dst, _dstride, _src, _sstride);
+#endif
+}
+
+void od_copy_nxm(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int n, int m) {
+  int j;
+  for (j = 0; j < m; j++) {
+    OD_COPY(_dst, _src, n);
+    _dst += _dstride;
+    _src += _sstride;
+  }
+}

--- a/src/util.c
+++ b/src/util.c
@@ -50,33 +50,20 @@ OD_COPY_C(16)
 OD_COPY_C(32)
 OD_COPY_C(64)
 
-typedef void (*od_copy_fixed_func)(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride);
+const od_copy_nxn_func OD_COPY_NXN_C[OD_LOG_COPYBSIZE_MAX + 1] = {
+  NULL,
+  od_copy_2x2_c,
+  od_copy_4x4_c,
+  od_copy_8x8_c,
+  od_copy_16x16_c,
+  od_copy_32x32_c,
+  od_copy_64x64_c
+};
 
-void od_copy_nxn_c(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int _log_n) {
-  static const od_copy_fixed_func
-   VTBL[7] = {
-    NULL,
-    od_copy_2x2_c,
-    od_copy_4x4_c,
-    od_copy_8x8_c,
-    od_copy_16x16_c,
-    od_copy_32x32_c,
-    od_copy_64x64_c
-  };
-  OD_ASSERT(_log_n > 0 || _log_n <= 6);
-  (*VTBL[_log_n])(_dst, _dstride, _src, _sstride);
-}
-
-void od_copy_nxm_c(unsigned char *_dst, int _dstride,
+void od_copy_nxm(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride, int _log_n, int _log_m) {
   int j;
-  if (_log_n == _log_m) {
-    od_copy_nxn_c(_dst, _dstride, _src, _sstride, _log_n);
-    return;
-  }
-  /* Handle non-square blocks. */
+  OD_ASSERT(_log_n != _log_m);
   for (j = 0; j < 1 << _log_m; j++) {
     OD_COPY(_dst, _src, 1 << _log_n);
     _dst += _dstride;

--- a/src/util.c
+++ b/src/util.c
@@ -92,23 +92,29 @@ void od_copy_64x64(unsigned char *_dst, int _dstride,
 #endif
 }
 
+typedef void (*od_copy_fixed_func)(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+
 void od_copy_log_nxm(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride, int _log_n, int _log_m) {
+  int j;
+  static const od_copy_fixed_func
+   VTBL[OD_LOG_BSIZE_MAX + 1] = {
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    od_copy_16x16,
+    od_copy_32x32,
+    od_copy_64x64
+  };
   if (_log_n == _log_m) {
-    if (_log_n == 4) {
-      od_copy_16x16(_dst, _dstride, _src, _sstride);
-      return;
-    }
-    else if (_log_n == 5) {
-      od_copy_32x32(_dst, _dstride, _src, _sstride);
-      return;
-    }
-    else if (_log_n == 6) {
-      od_copy_64x64(_dst, _dstride, _src, _sstride);
+    od_copy_fixed_func func = (*VTBL[_log_n]);
+    if (func != NULL) {
+      func(_dst, _dstride, _src, _sstride);
       return;
     }
   }
-  int j;
   for (j = 0; j < 1 << _log_m; j++) {
     OD_COPY(_dst, _src, 1 << _log_n);
     _dst += _dstride;

--- a/src/util.c
+++ b/src/util.c
@@ -62,6 +62,9 @@ void od_copy_64x64_c(unsigned char *_dst, int _dstride,
   }
 }
 
+/*Block copy functions. Copying of overlapping regions has undefined
+   behavior.*/
+
 void od_copy_16x16(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride) {
 #if defined(OD_SSE2_INTRINSICS)

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,6 @@ void od_copy_32x32(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
 void od_copy_64x64(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
-void od_copy_nxm(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int n, int m);
+void od_copy_log_nxm(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int _log_n, int _log_m);
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -25,14 +25,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #if !defined(_util_H)
 # define _util_H (1)
 
-void od_copy_16x16(unsigned char *_dst, int _dstride,
+void od_copy_2x2_c(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
-void od_copy_32x32(unsigned char *_dst, int _dstride,
+void od_copy_4x4_c(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
-void od_copy_64x64(unsigned char *_dst, int _dstride,
+void od_copy_8x8_c(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
-void od_copy_log_nxn(unsigned char *_dst, int _dstride,
+void od_copy_nxn_c(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride, int _log_n);
-void od_copy_log_nxm(unsigned char *_dst, int _dstride,
+void od_copy_nxm_c(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride, int _log_n, int _log_m);
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,36 @@
+/*Daala video codec
+Copyright (c) 2013 Daala project contributors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+
+#if !defined(_util_H)
+# define _util_H (1)
+
+void od_copy_16x16(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+void od_copy_32x32(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+void od_copy_64x64(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+void od_copy_nxm(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int n, int m);
+#endif

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,8 @@ void od_copy_32x32(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
 void od_copy_64x64(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
+void od_copy_log_nxn(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int _log_n);
 void od_copy_log_nxm(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride, int _log_n, int _log_m);
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -25,14 +25,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #if !defined(_util_H)
 # define _util_H (1)
 
-void od_copy_2x2_c(unsigned char *_dst, int _dstride,
+typedef void (*od_copy_nxn_func)(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride);
-void od_copy_4x4_c(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride);
-void od_copy_8x8_c(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride);
-void od_copy_nxn_c(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int _log_n);
-void od_copy_nxm_c(unsigned char *_dst, int _dstride,
+
+extern const od_copy_nxn_func OD_COPY_NXN_C[OD_LOG_COPYBSIZE_MAX + 1];
+void od_copy_nxm(unsigned char *_dst, int _dstride,
  const unsigned char *_src, int _sstride, int _log_n, int _log_m);
 #endif

--- a/src/x86/sse2mc.c
+++ b/src/x86/sse2mc.c
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include "x86int.h"
 #include "cpu.h"
 #include "../mc.h"
+#include "../util.h"
 
 #if defined(OD_X86ASM)
 #include <xmmintrin.h>
@@ -541,10 +542,17 @@ void od_mc_predict1fmv8_sse2(unsigned char *dst,const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    for (j = 0; j < yblk_sz; j++) {
-      OD_COPY(dst_p, src_p, xblk_sz);
-      src_p += systride;
-      dst_p += xblk_sz;
+    if (yblk_sz == xblk_sz && yblk_sz == 16) {
+      od_copy_16x16_sse2(dst_p, xblk_sz, src_p, systride);
+    }
+    else if (yblk_sz == xblk_sz && yblk_sz == 32) {
+      od_copy_32x32_sse2(dst_p, xblk_sz, src_p, systride);
+    }
+    else if (yblk_sz == xblk_sz && yblk_sz == 64) {
+      od_copy_64x64_sse2(dst_p, xblk_sz, src_p, systride);
+    }
+    else {
+      od_copy_nxm(dst_p, xblk_sz, src_p, systride, xblk_sz, yblk_sz);
     }
   }
 #if defined(OD_CHECKASM)

--- a/src/x86/sse2mc.c
+++ b/src/x86/sse2mc.c
@@ -542,18 +542,7 @@ void od_mc_predict1fmv8_sse2(unsigned char *dst,const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    if (yblk_sz == xblk_sz && yblk_sz == 16) {
-      od_copy_16x16_sse2(dst_p, xblk_sz, src_p, systride);
-    }
-    else if (yblk_sz == xblk_sz && yblk_sz == 32) {
-      od_copy_32x32_sse2(dst_p, xblk_sz, src_p, systride);
-    }
-    else if (yblk_sz == xblk_sz && yblk_sz == 64) {
-      od_copy_64x64_sse2(dst_p, xblk_sz, src_p, systride);
-    }
-    else {
-      od_copy_nxm(dst_p, xblk_sz, src_p, systride, xblk_sz, yblk_sz);
-    }
+    od_copy_log_nxm(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
   }
 #if defined(OD_CHECKASM)
   od_mc_predict1fmv8_check(dst, src, systride, mvx, mvy,

--- a/src/x86/sse2mc.c
+++ b/src/x86/sse2mc.c
@@ -358,8 +358,8 @@ typedef void (*od_mc_predict1fmv8_horizontal_fixed_func)(int16_t *buff_p,
  const unsigned char *src_p, int systride, int mvxf, int mvyf);
 
 #if defined(OD_SSE2_INTRINSICS)
-void od_mc_predict1fmv8_sse2(unsigned char *dst,const unsigned char *src,
- int systride, int32_t mvx, int32_t mvy,
+void od_mc_predict1fmv8_sse2(od_state *state, unsigned char *dst,
+ const unsigned char *src, int systride, int32_t mvx, int32_t mvy,
  int log_xblk_sz, int log_yblk_sz) {
   static const od_mc_predict1fmv8_horizontal_fixed_func VTBL_HORIZONTAL[5] = {
     od_mc_predict1fmv8_horizontal_2x2, od_mc_predict1fmv8_horizontal_4x4,
@@ -542,7 +542,8 @@ void od_mc_predict1fmv8_sse2(unsigned char *dst,const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    od_copy_nxm_sse2(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
+    OD_ASSERT(log_xblk_sz == log_yblk_sz);
+    (*state->opt_vtbl.od_copy_nxn[log_xblk_sz])(dst_p, xblk_sz, src_p, systride);
   }
 #if defined(OD_CHECKASM)
   od_mc_predict1fmv8_check(dst, src, systride, mvx, mvy,

--- a/src/x86/sse2mc.c
+++ b/src/x86/sse2mc.c
@@ -542,7 +542,7 @@ void od_mc_predict1fmv8_sse2(unsigned char *dst,const unsigned char *src,
   }
   /*MC with full-pel MV, i.e. integer position.*/
   else {
-    od_copy_log_nxm(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
+    od_copy_nxm_sse2(dst_p, xblk_sz, src_p, systride, log_xblk_sz, log_yblk_sz);
   }
 #if defined(OD_CHECKASM)
   od_mc_predict1fmv8_check(dst, src, systride, mvx, mvy,

--- a/src/x86/sse2util.c
+++ b/src/x86/sse2util.c
@@ -150,37 +150,4 @@ void od_copy_64x64_sse2(unsigned char *_dst, int _dstride,
     );
   }
 }
-
-typedef void (*od_copy_fixed_func)(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride);
-
-void od_copy_nxn_sse2(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int _log_n) {
-  static const od_copy_fixed_func
-   VTBL[7] = {
-    NULL,
-    od_copy_2x2_c,
-    od_copy_4x4_c,
-    od_copy_8x8_c,
-    od_copy_16x16_sse2,
-    od_copy_32x32_sse2,
-    od_copy_64x64_sse2
-  };
-  OD_ASSERT(_log_n > 0 || _log_n <= 6);
-  (*VTBL[_log_n])(_dst, _dstride, _src, _sstride);
-}
-
-void od_copy_nxm_sse2(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int _log_n, int _log_m) {
-  int j;
-  if (_log_n == _log_m) {
-    od_copy_nxn_sse2(_dst, _dstride, _src, _sstride, _log_n);
-    return;
-  }
-  for (j = 0; j < 1 << _log_m; j++) {
-    OD_COPY(_dst, _src, 1 << _log_n);
-    _dst += _dstride;
-    _src += _sstride;
-  }
-}
 #endif

--- a/src/x86/sse2util.c
+++ b/src/x86/sse2util.c
@@ -31,10 +31,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include <string.h>
 #include "x86int.h"
 #include "cpu.h"
+#include "../mc.h"
+#include "../util.h"
+
+/*Block copy functions. Copying of overlapping regions has undefined
+   behavior. Only 16x16, 32x32, 64x64 show a SIMD improvement.*/
 
 #if defined(OD_X86ASM)
-
-#if defined(OD_SSE2_INTRINSICS)
 #define OD_IM_LOAD_1(_rega, _regb, _regc, _regd) \
   "#OD_IM_LOAD_1\n\t" \
   "movdqu (%[src]), " _rega "\n\t" \
@@ -147,5 +150,37 @@ void od_copy_64x64_sse2(unsigned char *_dst, int _dstride,
     );
   }
 }
-#endif
+
+typedef void (*od_copy_fixed_func)(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+
+void od_copy_nxn_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int _log_n) {
+  static const od_copy_fixed_func
+   VTBL[7] = {
+    NULL,
+    od_copy_2x2_c,
+    od_copy_4x4_c,
+    od_copy_8x8_c,
+    od_copy_16x16_sse2,
+    od_copy_32x32_sse2,
+    od_copy_64x64_sse2
+  };
+  OD_ASSERT(_log_n > 0 || _log_n <= 6);
+  (*VTBL[_log_n])(_dst, _dstride, _src, _sstride);
+}
+
+void od_copy_nxm_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int _log_n, int _log_m) {
+  int j;
+  if (_log_n == _log_m) {
+    od_copy_nxn_sse2(_dst, _dstride, _src, _sstride, _log_n);
+    return;
+  }
+  for (j = 0; j < 1 << _log_m; j++) {
+    OD_COPY(_dst, _src, 1 << _log_n);
+    _dst += _dstride;
+    _src += _sstride;
+  }
+}
 #endif

--- a/src/x86/x86int.h
+++ b/src/x86/x86int.h
@@ -61,5 +61,10 @@ void od_bin_fdct8x8_avx2(od_coeff *y, int ystride,
  const od_coeff *x, int xstride);
 void od_bin_idct8x8_avx2(od_coeff *x, int xstride,
  const od_coeff *y, int ystride);
-
+void od_copy_16x16_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+void od_copy_32x32_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+void od_copy_64x64_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
 #endif

--- a/src/x86/x86int.h
+++ b/src/x86/x86int.h
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 
 void od_state_opt_vtbl_init_x86(od_state *_state);
 
-void od_mc_predict1fmv8_sse2(unsigned char *_dst,const unsigned char *_src,
+void od_mc_predict1fmv8_sse2(od_state *state, unsigned char *_dst,const unsigned char *_src,
  int _systride,int32_t _mvx,int32_t _mvy,
  int _log_xblk_sz,int _log_yblk_sz);
 void od_mc_blend_full8_sse2(unsigned char *_dst,int _dystride,
@@ -61,8 +61,10 @@ void od_bin_fdct8x8_avx2(od_coeff *y, int ystride,
  const od_coeff *x, int xstride);
 void od_bin_idct8x8_avx2(od_coeff *x, int xstride,
  const od_coeff *y, int ystride);
-void od_copy_nxn_sse2(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int _log_n);
-void od_copy_nxm_sse2(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride, int _log_n, int _log_m);
+void od_copy_16x16_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+void od_copy_32x32_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
+void od_copy_64x64_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride);
 #endif

--- a/src/x86/x86int.h
+++ b/src/x86/x86int.h
@@ -61,10 +61,8 @@ void od_bin_fdct8x8_avx2(od_coeff *y, int ystride,
  const od_coeff *x, int xstride);
 void od_bin_idct8x8_avx2(od_coeff *x, int xstride,
  const od_coeff *y, int ystride);
-void od_copy_16x16_sse2(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride);
-void od_copy_32x32_sse2(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride);
-void od_copy_64x64_sse2(unsigned char *_dst, int _dstride,
- const unsigned char *_src, int _sstride);
+void od_copy_nxn_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int _log_n);
+void od_copy_nxm_sse2(unsigned char *_dst, int _dstride,
+ const unsigned char *_src, int _sstride, int _log_n, int _log_m);
 #endif

--- a/src/x86/x86state.c
+++ b/src/x86/x86state.c
@@ -51,8 +51,9 @@ void od_state_opt_vtbl_init_x86(od_state *_state){
     _state->opt_vtbl.idct_2d[0] = od_bin_idct4x4_sse2;
     _state->opt_vtbl.fdct_2d[1] = od_bin_fdct8x8_sse2;
     _state->opt_vtbl.idct_2d[1] = od_bin_idct8x8_sse2;
-    _state->opt_vtbl.od_copy_nxm = od_copy_nxm_sse2;
-    _state->opt_vtbl.od_copy_nxn = od_copy_nxn_sse2;
+    _state->opt_vtbl.od_copy_nxn[4] = od_copy_16x16_sse2;
+    _state->opt_vtbl.od_copy_nxn[5] = od_copy_32x32_sse2;
+    _state->opt_vtbl.od_copy_nxn[6] = od_copy_64x64_sse2;
 #endif
 #if defined(OD_SSE41_INTRINSICS)
     if (_state->cpu_flags&OD_CPU_X86_SSE4_1) {

--- a/src/x86/x86state.c
+++ b/src/x86/x86state.c
@@ -51,6 +51,8 @@ void od_state_opt_vtbl_init_x86(od_state *_state){
     _state->opt_vtbl.idct_2d[0] = od_bin_idct4x4_sse2;
     _state->opt_vtbl.fdct_2d[1] = od_bin_fdct8x8_sse2;
     _state->opt_vtbl.idct_2d[1] = od_bin_idct8x8_sse2;
+    _state->opt_vtbl.od_copy_nxm = od_copy_nxm_sse2;
+    _state->opt_vtbl.od_copy_nxn = od_copy_nxn_sse2;
 #endif
 #if defined(OD_SSE41_INTRINSICS)
     if (_state->cpu_flags&OD_CPU_X86_SSE4_1) {

--- a/src/x86/x86util.c
+++ b/src/x86/x86util.c
@@ -1,0 +1,151 @@
+/*Daala video codec
+Copyright (c) 2006-2015 Daala project contributors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include "x86int.h"
+#include "cpu.h"
+
+#if defined(OD_X86ASM)
+
+#if defined(OD_SSE2_INTRINSICS)
+#define OD_IM_LOAD_1(_rega, _regb, _regc, _regd) \
+  "#OD_IM_LOAD_1\n\t" \
+  "movdqu (%[src]), " _rega "\n\t" \
+  "lea (%[src],%[sstride]),%[src] \n\t" \
+  "movdqu (%[src]), " _regb "\n\t" \
+  "lea (%[src],%[sstride]),%[src] \n\t" \
+  "movdqu (%[src]), " _regc "\n\t" \
+  "lea (%[src],%[sstride]),%[src] \n\t" \
+  "movdqu (%[src]), " _regd "\n\t" \
+  "lea (%[src],%[sstride]),%[src] \n\t" \
+
+#define OD_IM_STORE_1(_rega, _regb, _regc, _regd) \
+  "#OD_IM_STORE_1\n\t" \
+  "movdqu " _rega ",(%[dst]) \n\t" \
+  "lea (%[dst],%[dstride]),%[dst] \n\t" \
+  "movdqu " _regb ",(%[dst]) \n\t" \
+  "lea (%[dst],%[dstride]),%[dst] \n\t" \
+  "movdqu " _regc ",(%[dst]) \n\t" \
+  "lea (%[dst],%[dstride]),%[dst]\n\t" \
+  "movdqu " _regd ",(%[dst]) \n\t" \
+  "lea (%[dst],%[dstride]),%[dst]\n\t" \
+
+void od_copy_16x16_sse2(unsigned char *_dst, int _dstride,
+  const unsigned char *_src, int _sstride) {
+  __asm__ __volatile__(
+    OD_IM_LOAD_1 ("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+    OD_IM_LOAD_1 ("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+    OD_IM_STORE_1("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+    OD_IM_STORE_1("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+    OD_IM_LOAD_1 ("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+    OD_IM_LOAD_1 ("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+    OD_IM_STORE_1("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+    OD_IM_STORE_1("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+    :[dst]"+r"(_dst),[src]"+r"(_src)
+    :[dstride]"r"((ptrdiff_t)_dstride),[sstride]"r"((ptrdiff_t)_sstride)
+    :"xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7"
+  );
+}
+
+#define OD_IM_LOAD_2(_rega, _regb, _regc, _regd) \
+  "#OD_IM_LOAD_2\n\t" \
+  "movdqu (%[src]), " _rega "\n\t" \
+  "movdqu 16(%[src]), " _regb "\n\t" \
+  "lea (%[src],%[sstride]),%[src] \n\t" \
+  "movdqu (%[src]), " _regc "\n\t" \
+  "movdqu 16(%[src]), " _regd "\n\t" \
+  "lea (%[src],%[sstride]),%[src] \n\t" \
+
+#define OD_IM_STORE_2(_rega, _regb, _regc, _regd) \
+  "#OD_IM_STORE_1\n\t" \
+  "movdqu " _rega ",(%[dst]) \n\t" \
+  "movdqu " _regb ",16(%[dst]) \n\t" \
+  "lea (%[dst],%[dstride]),%[dst] \n\t" \
+  "movdqu " _regc ",(%[dst]) \n\t" \
+  "movdqu " _regd ",16(%[dst]) \n\t" \
+  "lea (%[dst],%[dstride]),%[dst]\n\t" \
+
+void od_copy_32x32_sse2(unsigned char *_dst, int _dstride,
+  const unsigned char *_src, int _sstride) {
+  int i;
+  for (i = 0; i < 4; i++) {
+    __asm__ __volatile__(
+      OD_IM_LOAD_2 ("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_LOAD_2 ("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      OD_IM_STORE_2("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_STORE_2("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      OD_IM_LOAD_2 ("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_LOAD_2 ("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      OD_IM_STORE_2("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_STORE_2("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      :[dst]"+r"(_dst),[src]"+r"(_src)
+      :[dstride]"r"((ptrdiff_t)_dstride),[sstride]"r"((ptrdiff_t)_sstride)
+      :"xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7"
+    );
+  }
+}
+
+#define OD_IM_LOAD_4(_rega, _regb, _regc, _regd) \
+  "#OD_IM_LOAD_4\n\t" \
+  "movdqu (%[src]), " _rega "\n\t" \
+  "movdqu 16(%[src]), " _regb "\n\t" \
+  "movdqu 32(%[src]), " _regc "\n\t" \
+  "movdqu 48(%[src]), " _regd "\n\t" \
+  "lea (%[src],%[sstride]),%[src] \n\t" \
+
+#define OD_IM_STORE_4(_rega, _regb, _regc, _regd) \
+  "#OD_IM_STORE_4\n\t" \
+  "movdqu " _rega ",(%[dst]) \n\t" \
+  "movdqu " _regb ",16(%[dst]) \n\t" \
+  "movdqu " _regc ",32(%[dst]) \n\t" \
+  "movdqu " _regd ",48(%[dst]) \n\t" \
+  "lea (%[dst],%[dstride]),%[dst]\n\t" \
+
+void od_copy_64x64_sse2(unsigned char *_dst, int _dstride,
+  const unsigned char *_src, int _sstride) {
+  int i;
+  for (i = 0; i < 16; i++) {
+    __asm__ __volatile__(
+      OD_IM_LOAD_4 ("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_LOAD_4 ("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      OD_IM_STORE_4("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_STORE_4("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      OD_IM_LOAD_4 ("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_LOAD_4 ("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      OD_IM_STORE_4("%%xmm0", "%%xmm1", "%%xmm2", "%%xmm3")
+      OD_IM_STORE_4("%%xmm4", "%%xmm5", "%%xmm6", "%%xmm7")
+      :[dst]"+r"(_dst),[src]"+r"(_src)
+      :[dstride]"r"((ptrdiff_t)_dstride),[sstride]"r"((ptrdiff_t)_sstride)
+      :"xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7"
+    );
+  }
+}
+#endif
+#endif


### PR DESCRIPTION
This improves block copying performance between `20%` and `50%` when SSE2 is available. 8x8, 4x4 and 2x2 did not show any improvement. 

```
16x16
sse2 0.518970s
   c 0.766928s
32x32
sse2 2.621024s
   c 3.184177s
64x64
sse2 5.729582s
   c 10.430384s
```