### PR TITLE
SIMD code for deringing filter.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,7 +101,7 @@ src_libdaalabase_la_SOURCES = \
 if ENABLE_X86ASM
 src_libdaalabase_la_SOURCES += \
 	src/x86/sse2mc.c \
-	src/x86/x86filter.c \
+	src/x86/sse2filter.c \
 	src/x86/x86state.c
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -101,6 +101,7 @@ src_libdaalabase_la_SOURCES = \
 if ENABLE_X86ASM
 src_libdaalabase_la_SOURCES += \
 	src/x86/sse2mc.c \
+	src/x86/x86filter.c \
 	src/x86/x86state.c
 endif
 
@@ -332,6 +333,7 @@ tools_upsample_SOURCES = \
 if ENABLE_X86ASM
 tools_upsample_SOURCES += \
 	src/x86/sse2mc.c \
+	src/x86/x86filter.c \
 	src/x86/x86state.c
 endif
 tools_upsample_CFLAGS = $(THEORA_CFLAGS) $(OGG_CFLAGS) $(PNG_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -333,7 +333,6 @@ tools_upsample_SOURCES = \
 if ENABLE_X86ASM
 tools_upsample_SOURCES += \
 	src/x86/sse2mc.c \
-	src/x86/x86filter.c \
 	src/x86/x86state.c
 endif
 tools_upsample_CFLAGS = $(THEORA_CFLAGS) $(OGG_CFLAGS) $(PNG_CFLAGS)

--- a/src/decode.c
+++ b/src/decode.c
@@ -1063,7 +1063,8 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
               the input to the filter, but because we look past block edges,
               we do this anyway on the edge pixels. Unfortunately, this limits
               potential parallelism.*/
-            od_dering(buf, OD_BSIZE_MAX, &state->etmp[pli][(sby << ln)*w +
+            od_dering(state, buf, OD_BSIZE_MAX,
+             &state->etmp[pli][(sby << ln)*w +
              (sbx << ln)], w, ln, sbx, sby, nhsb, nvsb, dec->quantizer[pli],
              xdec, dir, pli, &dec->state.bskip[pli]
              [(sby << (OD_NBSIZES - 1 - ydec))*dec->state.skip_stride

--- a/src/encode.c
+++ b/src/encode.c
@@ -2379,7 +2379,7 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
         OD_ASSERT(xdec == ydec);
         ln = OD_LOG_BSIZE_MAX - xdec;
         n = 1 << ln;
-        od_dering(buf, OD_BSIZE_MAX, &state->etmp[pli][(sby << ln)*w +
+        od_dering(state, buf, OD_BSIZE_MAX, &state->etmp[pli][(sby << ln)*w +
          (sbx << ln)], w, ln, sbx, sby, nhsb, nvsb, enc->quantizer[0], xdec,
          dir, pli, &enc->state.bskip[pli]
          [(sby << (OD_NBSIZES - 1 - ydec))*enc->state.skip_stride
@@ -2455,7 +2455,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
             w = frame_width >> xdec;
             ln = OD_LOG_BSIZE_MAX - xdec;
             n = 1 << ln;
-            od_dering(buf, OD_BSIZE_MAX, &state->etmp[pli][(sby << ln)*w +
+            od_dering(state, buf, OD_BSIZE_MAX,
+             &state->etmp[pli][(sby << ln)*w +
              (sbx << ln)], w, ln, sbx, sby, nhsb, nvsb, enc->quantizer[pli],
              xdec, dir, pli, &enc->state.bskip[pli]
              [(sby << (OD_NBSIZES - 1 - ydec))*enc->state.skip_stride

--- a/src/filter.c
+++ b/src/filter.c
@@ -1684,7 +1684,7 @@ void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
   int i;
   int j;
   int k;
-  static const int taps[4] = {3, 2, 2};
+  static const int taps[3] = {3, 2, 2};
   for (i = 0; i < 1 << ln; i++) {
     for (j = 0; j < 1 << ln; j++) {
       od_coeff sum;
@@ -1707,15 +1707,15 @@ void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
 }
 
 /* Smooth in the direction orthogonal to what was detected. */
-static void od_dering_orthogonal(int16_t *y, int ystride, int16_t *in,
- int16_t *x, int xstride, int n, int threshold, int dir) {
+void od_filter_dering_orthogonal_c(int16_t *y, int ystride, int16_t *in,
+ int16_t *x, int xstride, int ln, int threshold, int dir) {
   int i;
   int j;
   int offset;
   if (dir <= 4) offset = OD_FILT_BSTRIDE;
   else offset = 1;
-  for (i = 0; i < n; i++) {
-    for (j = 0; j < n; j++) {
+  for (i = 0; i < 1 << ln; i++) {
+    for (j = 0; j < 1 << ln; j++) {
       od_coeff athresh;
       od_coeff yy;
       od_coeff sum;
@@ -1876,9 +1876,9 @@ void od_dering(od_state *state, int16_t *y, int ystride, int16_t *x, int xstride
   }
   for (by = 0; by < nvb; by++) {
     for (bx = 0; bx < nhb; bx++) {
-      od_dering_orthogonal(&y[(by*ystride << bsize) + (bx << bsize)], ystride,
+      (*state->opt_vtbl.filter_dering_orthogonal)(&y[(by*ystride << bsize) + (bx << bsize)], ystride,
        &in[(by*OD_FILT_BSTRIDE << bsize) + (bx << bsize)],
-       &x[(by*xstride << bsize) + (bx << bsize)], xstride, 1 << bsize,
+       &x[(by*xstride << bsize) + (bx << bsize)], xstride, bsize,
        thresh[by][bx], dir[by][bx]);
     }
   }

--- a/src/filter.c
+++ b/src/filter.c
@@ -1678,26 +1678,6 @@ static int od_dir_find8(const int16_t *img, int stride, int32_t *var) {
 #define OD_DERING_INBUF_SIZE ((OD_BSIZE_MAX + 2*OD_FILT_BORDER)*\
  (OD_BSIZE_MAX + 2*OD_FILT_BORDER))
 
-static const int direction_offsets_table[16][3] = {
-  { -37, -74,-111 },
-  {   1, -36, -35 },
-  {   1,   2,   3 },
-  {   1,  40,  41 },
-  {  39,  78, 117 },
-  {  38,  77, 115 },
-  {  38,  76, 114 },
-  {  38,  75, 113 },
-  {  37,  74, 111 },
-  {  37,  73, 110 },
-  {  36,  72, 108 },
-  {  36,  71, 107 },
-  {  35,  70, 105 },
-  {  35,  69, 104 },
-  {  34,  68, 102 },
-  {  34,  67, 101 }
-};
-
-
 /* Smooth in the direction detected. */
 void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
  int ln, int threshold, int dir) {

--- a/src/filter.c
+++ b/src/filter.c
@@ -1680,37 +1680,24 @@ static int od_dir_find8(const int16_t *img, int stride, int32_t *var) {
  (OD_BSIZE_MAX + 2*OD_FILT_BORDER))
 
 static const int direction_offsets_table[16][3] = {
-   {-37, -74,-111 },
-   {  1, -36, -35 },
-   {  1,   2,   3 },
-   {  1,  40,  41 },
-   { 39,  78, 117 },
-   { 38,  77, 115 },
-   { 38,  76, 114 },
-   { 38,  75, 113 },
-   { 37,  74, 111 },
-   { 37,  73, 110 },
-   { 36,  72, 108 },
-   { 36,  71, 107 },
-   { 35,  70, 105 },
-   { 35,  69, 104 },
-   { 34,  68, 102 },
-   { 34,  67, 101 }
+  { -37, -74,-111 },
+  {   1, -36, -35 },
+  {   1,   2,   3 },
+  {   1,  40,  41 },
+  {  39,  78, 117 },
+  {  38,  77, 115 },
+  {  38,  76, 114 },
+  {  38,  75, 113 },
+  {  37,  74, 111 },
+  {  37,  73, 110 },
+  {  36,  72, 108 },
+  {  36,  71, 107 },
+  {  35,  70, 105 },
+  {  35,  69, 104 },
+  {  34,  68, 102 },
+  {  34,  67, 101 }
 };
 
-/* Build offset table. */
-void od_filter_dering_direction_offsets(int *offset, int dir, int bstride) {
-  int k;
-  int f;
-  if (dir <= 4) {
-    f = dir - 2;
-    for (k = 1; k <= 3; k++) offset[k - 1] = f*k/2*bstride + k;
-  }
-  else {
-    f = 6 - dir;
-    for (k = 1; k <= 3; k++) offset[k - 1] = k*bstride + f*k/2;
-  }
-}
 
 /* Smooth in the direction detected. */
 void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,

--- a/src/filter.c
+++ b/src/filter.c
@@ -1700,13 +1700,13 @@ static const int direction_offsets_table[16][3] = {
 
 /* Smooth in the direction detected. */
 void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
- int log_n, int threshold, int dir) {
+ int ln, int threshold, int dir) {
   int i;
   int j;
   int k;
   static const int taps[4] = {3, 2, 2};
-  for (i = 0; i < 1 << log_n; i++) {
-    for (j = 0; j < 1 << log_n; j++) {
+  for (i = 0; i < 1 << ln; i++) {
+    for (j = 0; j < 1 << ln; j++) {
       od_coeff sum;
       od_coeff xx;
       od_coeff yy;

--- a/src/filter.c
+++ b/src/filter.c
@@ -1679,6 +1679,25 @@ static int od_dir_find8(const int16_t *img, int stride, int32_t *var) {
 #define OD_DERING_INBUF_SIZE ((OD_BSIZE_MAX + 2*OD_FILT_BORDER)*\
  (OD_BSIZE_MAX + 2*OD_FILT_BORDER))
 
+static const int direction_offsets_table[16][3] = {
+   {-37, -74,-111 },
+   {  1, -36, -35 },
+   {  1,   2,   3 },
+   {  1,  40,  41 },
+   { 39,  78, 117 },
+   { 38,  77, 115 },
+   { 38,  76, 114 },
+   { 38,  75, 113 },
+   { 37,  74, 111 },
+   { 37,  73, 110 },
+   { 36,  72, 108 },
+   { 36,  71, 107 },
+   { 35,  70, 105 },
+   { 35,  69, 104 },
+   { 34,  68, 102 },
+   { 34,  67, 101 }
+};
+
 /* Build offset table. */
 void od_filter_dering_direction_offsets(int *offset, int dir, int bstride) {
   int k;
@@ -1700,8 +1719,6 @@ void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
   int j;
   int k;
   static const int taps[4] = {3, 2, 2};
-  int offset[4];
-  od_filter_dering_direction_offsets(offset, dir, bstride);
   for (i = 0; i < 1 << log_n; i++) {
     for (j = 0; j < 1 << log_n; j++) {
       od_coeff sum;
@@ -1712,8 +1729,8 @@ void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
       for (k = 0; k < 3; k++) {
         od_coeff p0;
         od_coeff p1;
-        p0 = in[i*bstride + j + offset[k]] - xx;
-        p1 = in[i*bstride + j - offset[k]] - xx;
+        p0 = in[i*bstride + j + direction_offsets_table[dir][k]] - xx;
+        p1 = in[i*bstride + j - direction_offsets_table[dir][k]] - xx;
         if (abs(p0) < threshold) sum += taps[k]*p0;
         if (abs(p1) < threshold) sum += taps[k]*p1;
       }

--- a/src/filter.h
+++ b/src/filter.h
@@ -26,6 +26,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 # define _filter_H (1)
 # include "internal.h"
 
+struct od_state;
+
 typedef int32_t od_coeff;
 # define OD_COEFF_BITS (32)
 
@@ -81,10 +83,13 @@ void od_apply_postfilter_frame(od_coeff *c, int w, int nhsb, int nvsb,
 #define OD_DERING_NBLOCKS (OD_BSIZE_MAX/8)
 
 extern const int OD_FILT_SIZE[OD_NBSIZES];
-void od_dering(int16_t *y, int ystride, int16_t *x, int xstride, int ln,
- int sbx, int sby, int nhsb, int nvsb, int q, int xdec,
+void od_dering(struct od_state *state, int16_t *y, int ystride, int16_t *x,
+ int xstride, int ln, int sbx, int sby, int nhsb, int nvsb, int q, int xdec,
  int dir[OD_DERING_NBLOCKS][OD_DERING_NBLOCKS], int pli, unsigned char *bskip,
  int skip_stride);
+void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
+ int bstride, int log_n, int threshold, int dir);
+void od_filter_dering_direction_offsets(int *offset, int dir, int bstride);
 void od_clpf(od_coeff *y, int ystride, od_coeff *x, int xstride, int ln,
  int sbx, int sby, int nhsb, int nvsb);
 void od_bilinear_smooth(od_coeff *x, int ln, int stride, int q, int pli);

--- a/src/filter.h
+++ b/src/filter.h
@@ -82,6 +82,9 @@ void od_apply_postfilter_frame(od_coeff *c, int w, int nhsb, int nvsb,
 #define OD_FILT_SIZE(ln, xdec) (0)
 #define OD_DERING_NBLOCKS (OD_BSIZE_MAX/8)
 
+#define OD_FILT_BORDER (3)
+#define OD_FILT_BSTRIDE (OD_BSIZE_MAX + 2*OD_FILT_BORDER)
+
 static const int direction_offsets_table[16][3];
 
 extern const int OD_FILT_SIZE[OD_NBSIZES];
@@ -90,7 +93,7 @@ void od_dering(struct od_state *state, int16_t *y, int ystride, int16_t *x,
  int dir[OD_DERING_NBLOCKS][OD_DERING_NBLOCKS], int pli, unsigned char *bskip,
  int skip_stride);
 void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
- int bstride, int log_n, int threshold, int dir);
+ int log_n, int threshold, int dir);
 void od_clpf(od_coeff *y, int ystride, od_coeff *x, int xstride, int ln,
  int sbx, int sby, int nhsb, int nvsb);
 void od_bilinear_smooth(od_coeff *x, int ln, int stride, int q, int pli);

--- a/src/filter.h
+++ b/src/filter.h
@@ -111,6 +111,8 @@ void od_dering(struct od_state *state, int16_t *y, int ystride, int16_t *x,
  int skip_stride);
 void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
  int ln, int threshold, int dir);
+void od_filter_dering_orthogonal_c(int16_t *y, int ystride, int16_t *in,
+ int16_t *x, int xstride, int ln, int threshold, int dir);
 void od_clpf(od_coeff *y, int ystride, od_coeff *x, int xstride, int ln,
  int sbx, int sby, int nhsb, int nvsb);
 void od_bilinear_smooth(od_coeff *x, int ln, int stride, int q, int pli);

--- a/src/filter.h
+++ b/src/filter.h
@@ -82,6 +82,8 @@ void od_apply_postfilter_frame(od_coeff *c, int w, int nhsb, int nvsb,
 #define OD_FILT_SIZE(ln, xdec) (0)
 #define OD_DERING_NBLOCKS (OD_BSIZE_MAX/8)
 
+static const int direction_offsets_table[16][3];
+
 extern const int OD_FILT_SIZE[OD_NBSIZES];
 void od_dering(struct od_state *state, int16_t *y, int ystride, int16_t *x,
  int xstride, int ln, int sbx, int sby, int nhsb, int nvsb, int q, int xdec,
@@ -89,7 +91,6 @@ void od_dering(struct od_state *state, int16_t *y, int ystride, int16_t *x,
  int skip_stride);
 void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
  int bstride, int log_n, int threshold, int dir);
-void od_filter_dering_direction_offsets(int *offset, int dir, int bstride);
 void od_clpf(od_coeff *y, int ystride, od_coeff *x, int xstride, int ln,
  int sbx, int sby, int nhsb, int nvsb);
 void od_bilinear_smooth(od_coeff *x, int ln, int stride, int q, int pli);

--- a/src/filter.h
+++ b/src/filter.h
@@ -93,7 +93,7 @@ void od_dering(struct od_state *state, int16_t *y, int ystride, int16_t *x,
  int dir[OD_DERING_NBLOCKS][OD_DERING_NBLOCKS], int pli, unsigned char *bskip,
  int skip_stride);
 void od_filter_dering_direction_c(int16_t *y, int ystride, int16_t *in,
- int log_n, int threshold, int dir);
+ int ln, int threshold, int dir);
 void od_clpf(od_coeff *y, int ystride, od_coeff *x, int xstride, int ln,
  int sbx, int sby, int nhsb, int nvsb);
 void od_bilinear_smooth(od_coeff *x, int ln, int stride, int q, int pli);

--- a/src/filter.h
+++ b/src/filter.h
@@ -85,7 +85,24 @@ void od_apply_postfilter_frame(od_coeff *c, int w, int nhsb, int nvsb,
 #define OD_FILT_BORDER (3)
 #define OD_FILT_BSTRIDE (OD_BSIZE_MAX + 2*OD_FILT_BORDER)
 
-static const int direction_offsets_table[16][3];
+static const int direction_offsets_table[16][3] = {
+  { -37, -74,-111 },
+  {   1, -36, -35 },
+  {   1,   2,   3 },
+  {   1,  40,  41 },
+  {  39,  78, 117 },
+  {  38,  77, 115 },
+  {  38,  76, 114 },
+  {  38,  75, 113 },
+  {  37,  74, 111 },
+  {  37,  73, 110 },
+  {  36,  72, 108 },
+  {  36,  71, 107 },
+  {  35,  70, 105 },
+  {  35,  69, 104 },
+  {  34,  68, 102 },
+  {  34,  67, 101 }
+};
 
 extern const int OD_FILT_SIZE[OD_NBSIZES];
 void od_dering(struct od_state *state, int16_t *y, int ystride, int16_t *x,

--- a/src/state.c
+++ b/src/state.c
@@ -187,6 +187,7 @@ void od_state_opt_vtbl_init_c(od_state *state) {
   state->opt_vtbl.mc_blend_full_split = od_mc_blend_full_split8_c;
   state->opt_vtbl.mc_blend_multi = od_mc_blend_multi8_c;
   state->opt_vtbl.mc_blend_multi_split = od_mc_blend_multi_split8_c;
+  state->opt_vtbl.filter_dering_direction = od_filter_dering_direction_c;
   state->opt_vtbl.restore_fpu = od_restore_fpu_c;
   OD_COPY(state->opt_vtbl.fdct_2d, OD_FDCT_2D_C, OD_NBSIZES + 1);
   OD_COPY(state->opt_vtbl.idct_2d, OD_IDCT_2D_C, OD_NBSIZES + 1);

--- a/src/state.c
+++ b/src/state.c
@@ -188,6 +188,7 @@ void od_state_opt_vtbl_init_c(od_state *state) {
   state->opt_vtbl.mc_blend_multi = od_mc_blend_multi8_c;
   state->opt_vtbl.mc_blend_multi_split = od_mc_blend_multi_split8_c;
   state->opt_vtbl.filter_dering_direction = od_filter_dering_direction_c;
+  state->opt_vtbl.filter_dering_orthogonal = od_filter_dering_orthogonal_c;
   state->opt_vtbl.restore_fpu = od_restore_fpu_c;
   OD_COPY(state->opt_vtbl.fdct_2d, OD_FDCT_2D_C, OD_NBSIZES + 1);
   OD_COPY(state->opt_vtbl.idct_2d, OD_IDCT_2D_C, OD_NBSIZES + 1);

--- a/src/state.h
+++ b/src/state.h
@@ -110,7 +110,7 @@ struct od_state_opt_vtbl{
    const unsigned char *_src[4], int _c, int _s,
    int _log_xblk_sz, int _log_yblk_sz);
   void (*filter_dering_direction)(int16_t *y, int ystride, int16_t *in,
-   int log_n, int threshold, int dir);
+   int ln, int threshold, int dir);
   void (*restore_fpu)(void);
   od_dct_func_2d fdct_2d[OD_NBSIZES + 1];
   od_dct_func_2d idct_2d[OD_NBSIZES + 1];

--- a/src/state.h
+++ b/src/state.h
@@ -35,6 +35,7 @@ typedef struct od_pvq_codeword_ctx od_pvq_codeword_ctx;
 # include "internal.h"
 # include "dct.h"
 # include "mc.h"
+# include "filter.h"
 # include "pvq.h"
 # include "adapt.h"
 # include "generic_code.h"
@@ -108,6 +109,8 @@ struct od_state_opt_vtbl{
   void (*mc_blend_multi_split)(unsigned char *_dst, int _dystride,
    const unsigned char *_src[4], int _c, int _s,
    int _log_xblk_sz, int _log_yblk_sz);
+  void (*filter_dering_direction)(int16_t *y, int ystride, int16_t *in,
+   int bstride, int log_n, int threshold, int dir);
   void (*restore_fpu)(void);
   od_dct_func_2d fdct_2d[OD_NBSIZES + 1];
   od_dct_func_2d idct_2d[OD_NBSIZES + 1];

--- a/src/state.h
+++ b/src/state.h
@@ -111,6 +111,8 @@ struct od_state_opt_vtbl{
    int _log_xblk_sz, int _log_yblk_sz);
   void (*filter_dering_direction)(int16_t *y, int ystride, int16_t *in,
    int ln, int threshold, int dir);
+  void (*filter_dering_orthogonal)(int16_t *y, int ystride, int16_t *in,
+   int16_t *x, int xstride, int ln, int threshold, int dir);
   void (*restore_fpu)(void);
   od_dct_func_2d fdct_2d[OD_NBSIZES + 1];
   od_dct_func_2d idct_2d[OD_NBSIZES + 1];

--- a/src/state.h
+++ b/src/state.h
@@ -110,7 +110,7 @@ struct od_state_opt_vtbl{
    const unsigned char *_src[4], int _c, int _s,
    int _log_xblk_sz, int _log_yblk_sz);
   void (*filter_dering_direction)(int16_t *y, int ystride, int16_t *in,
-   int bstride, int log_n, int threshold, int dir);
+   int log_n, int threshold, int dir);
   void (*restore_fpu)(void);
   od_dct_func_2d fdct_2d[OD_NBSIZES + 1];
   od_dct_func_2d idct_2d[OD_NBSIZES + 1];

--- a/src/x86/sse2filter.c
+++ b/src/x86/sse2filter.c
@@ -37,14 +37,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 
 #if defined(OD_CHECKASM)
 void od_filter_dering_direction_check(int16_t *y, int ystride, int16_t *in,
- int log_n, int threshold, int dir) {
+ int ln, int threshold, int dir) {
   int16_t dst[OD_BSIZE_MAX*OD_BSIZE_MAX];
-  od_filter_dering_direction_c(dst, OD_BSIZE_MAX, in, log_n,
+  od_filter_dering_direction_c(dst, OD_BSIZE_MAX, in, ln,
    threshold, dir);
   int i;
   int j;
   int failed;
-  int n = 1 << log_n;
+  int n = 1 << ln;
   failed = 0;
   for (i = 0; i < n; i++) {
     for (j = 0; j < n; j++) {
@@ -158,17 +158,17 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
 }
 
 void od_filter_dering_direction_sse2(int16_t *y, int ystride, int16_t *in,
- int log_n, int threshold, int dir) {
+ int ln, int threshold, int dir) {
   static const od_filter_dering_direction_fixed_func VTBL[4] = {
     NULL,
     NULL,
     od_filter_dering_direction_4x4,
     od_filter_dering_direction_8x8,
   };
-  OD_ASSERT(log_n >= 2 && log_n < 4);
-  VTBL[log_n](y, ystride, in, threshold, dir);
+  OD_ASSERT(ln >= 2 && ln < 4);
+  VTBL[ln](y, ystride, in, threshold, dir);
 #if defined(OD_CHECKASM)
-  od_filter_dering_direction_check(y, ystride, in, log_n, threshold,
+  od_filter_dering_direction_check(y, ystride, in, ln, threshold,
    dir);
 #endif
 }

--- a/src/x86/sse2filter.c
+++ b/src/x86/sse2filter.c
@@ -76,7 +76,6 @@ void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
   int i;
   int k;
   static const int taps[3] = {3, 2, 2};
-  int offset[3];
   __m128i sum;
   __m128i p0;
   __m128i cmp0;
@@ -84,14 +83,13 @@ void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
   __m128i cmp1;
   __m128i row;
   __m128i res;
-  od_filter_dering_direction_offsets(offset, dir, bstride);
   for (i = 0; i < 4; i++) {
     sum = _mm_set1_epi16(0);
     row = _mm_loadl_epi64((__m128i*)&in[i*bstride]);
     for (k = 0; k < 3; k++) {
       /* p0 = in[i*bstride + offset[k]] - row */;
       p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride +
-       offset[k]]), row);
+       direction_offsets_table[dir][k]]), row);
       /* if (abs(p0) < threshold) sum += taps[k]*p0; */
       cmp0 = _mm_cmplt_epi16(_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
       p0 = _mm_mullo_epi16(p0, _mm_set1_epi16(taps[k]));
@@ -100,7 +98,7 @@ void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
 
       /* p0 = in[i*bstride + offset[k]] - row */;
       p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride -
-       offset[k]]), row);
+       direction_offsets_table[dir][k]]), row);
       /* if (abs(p1) < threshold) sum += taps[k]*p1; */
       cmp1 = _mm_cmplt_epi16(_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
       p1 = _mm_mullo_epi16(p1, _mm_set1_epi16(taps[k]));
@@ -121,7 +119,6 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
   int i;
   int k;
   static const int taps[3] = {3, 2, 2};
-  int offset[3];
   __m128i sum;
   __m128i p0;
   __m128i cmp0;
@@ -129,14 +126,13 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
   __m128i cmp1;
   __m128i row;
   __m128i res;
-  od_filter_dering_direction_offsets(offset, dir, bstride);
   for (i = 0; i < 8; i++) {
     sum = _mm_set1_epi16(0);
     row = _mm_loadu_si128((__m128i*)&in[i*bstride]);
     for (k = 0; k < 3; k++) {
       /* p0 = in[i*bstride + offset[k]] - row */;
       p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride +
-       offset[k]]), row);
+       direction_offsets_table[dir][k]]), row);
       /* if (abs(p0) < threshold) sum += taps[k]*p0; */
       cmp0 = _mm_cmplt_epi16(_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
       p0 = _mm_mullo_epi16(p0, _mm_set1_epi16(taps[k]));
@@ -145,7 +141,7 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
 
       /* p0 = in[i*bstride + offset[k]] - row */;
       p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride -
-       offset[k]]), row);
+       direction_offsets_table[dir][k]]), row);
       /* if (abs(p1) < threshold) sum += taps[k]*p1; */
       cmp1 = _mm_cmplt_epi16(_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
       p1 = _mm_mullo_epi16(p1, _mm_set1_epi16(taps[k]));

--- a/src/x86/x86filter.c
+++ b/src/x86/x86filter.c
@@ -1,5 +1,5 @@
 /*Daala video codec
-Copyright (c) 2013 Daala project contributors.  All rights reserved.
+Copyright (c) 2015 Daala project contributors.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -83,7 +83,7 @@ void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
     sum = _mm_set1_epi16(0);
     row = _mm_loadl_epi64((__m128i*)&in[i*bstride]);
     for (k = 0; k < 3; k++) {
-      /* p0 = in[i*bstride + j + offset[k]] - row */;
+      /* p0 = in[i*bstride + offset[k]] - row */;
       p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride +
        offset[k]]), row);
       /* if (abs(p0) < threshold) sum += taps[k]*p0; */
@@ -92,7 +92,7 @@ void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
       p0 = _mm_and_si128(p0, cmp0);
       sum = _mm_add_epi16(sum, p0);
 
-      /* p0 = in[i*bstride + j + offset[k]] - row */;
+      /* p0 = in[i*bstride + offset[k]] - row */;
       p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride -
        offset[k]]), row);
       /* if (abs(p1) < threshold) sum += taps[k]*p1; */
@@ -128,7 +128,7 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
     sum = _mm_set1_epi16(0);
     row = _mm_loadu_si128((__m128i*)&in[i*bstride]);
     for (k = 0; k < 3; k++) {
-      /* p0 = in[i*bstride + j + offset[k]] - row */;
+      /* p0 = in[i*bstride + offset[k]] - row */;
       p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride +
        offset[k]]), row);
       /* if (abs(p0) < threshold) sum += taps[k]*p0; */
@@ -137,7 +137,7 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
       p0 = _mm_and_si128(p0, cmp0);
       sum = _mm_add_epi16(sum, p0);
 
-      /* p0 = in[i*bstride + j + offset[k]] - row */;
+      /* p0 = in[i*bstride + offset[k]] - row */;
       p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride -
        offset[k]]), row);
       /* if (abs(p1) < threshold) sum += taps[k]*p1; */

--- a/src/x86/x86filter.c
+++ b/src/x86/x86filter.c
@@ -40,7 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 void od_filter_dering_direction_check(int16_t *y, int ystride, int16_t *in,
  int bstride, int log_n, int threshold, int dir) {
   int16_t dst[OD_BSIZE_MAX*OD_BSIZE_MAX];
-  od_filter_dering_direction_c(dst, OD_BSIZE_MAX, in, bstride, log_n, threshold, dir);
+  od_filter_dering_direction_c(dst, OD_BSIZE_MAX, in, bstride, log_n,
+   threshold, dir);
   int i;
   int j;
   int failed;
@@ -63,13 +64,6 @@ void od_filter_dering_direction_check(int16_t *y, int ystride, int16_t *in,
 
 typedef void (*od_filter_dering_direction_fixed_func)(int16_t *y, int ystride,
  int16_t *in, int bstride, int threshold, int dir);
-
-void print_epi16(const char * name, __m128i var){
-  int16_t *val = (int16_t*) &var;
-  fprintf(stderr, "%8s int16_t: %4i %4i %4i %4i %4i %4i %4i %4i \n",
-   name, val[0], val[1], val[2], val[3], val[4], val[5],
-   val[6], val[7]);
-}
 
 void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
  int bstride, int threshold, int dir) {
@@ -95,7 +89,8 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
     row = _mm_loadu_si128((__m128i*)&in[i*bstride]);
     for (k = 0; k < 3; k++) {
       /* p0 = in[i*bstride + j + offset[k]] - row */;
-      p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride + offset[k]]), row);
+      p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride +
+       offset[k]]), row);
       /* if (abs(p0) < threshold) sum += taps[k]*p0; */
       cmp0 = _mm_cmplt_epi16(_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
       p0 = _mm_mullo_epi16(p0, _mm_set1_epi16(taps[k]));
@@ -103,7 +98,8 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
       sum = _mm_add_epi16(sum, p0);
 
       /* p0 = in[i*bstride + j + offset[k]] - row */;
-      p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride - offset[k]]), row);
+      p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride -
+       offset[k]]), row);
       /* if (abs(p1) < threshold) sum += taps[k]*p1; */
       cmp1 = _mm_cmplt_epi16(_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
       p1 = _mm_mullo_epi16(p1, _mm_set1_epi16(taps[k]));
@@ -133,9 +129,11 @@ void od_filter_dering_direction_sse2(int16_t *y, int ystride, int16_t *in,
     od_filter_dering_direction_8x8,
     od_filter_dering_direction_16x16
   };
+  OD_ASSERT(log_n >= 2 && log_n < 5);
   VTBL[log_n](y, ystride, in, bstride, threshold, dir);
 #if defined(OD_CHECKASM)
-  od_filter_dering_direction_check(y, ystride, in, bstride, log_n, threshold, dir);
+  od_filter_dering_direction_check(y, ystride, in, bstride, log_n, threshold,
+   dir);
 #endif
 }
 

--- a/src/x86/x86filter.c
+++ b/src/x86/x86filter.c
@@ -26,14 +26,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 # include "config.h"
 #endif
 
-#include "x86enc.h"
+#include "x86int.h"
 #include "cpu.h"
 
 #if defined(OD_X86ASM)
 #include <stdio.h>
 #include <emmintrin.h>
-#include <pmmintrin.h>
-#include <tmmintrin.h>
 #include "../filter.h"
 
 #if defined(OD_CHECKASM)
@@ -65,6 +63,14 @@ void od_filter_dering_direction_check(int16_t *y, int ystride, int16_t *in,
 typedef void (*od_filter_dering_direction_fixed_func)(int16_t *y, int ystride,
  int16_t *in, int bstride, int threshold, int dir);
 
+
+/*Corresponds to _mm_abs_epi16 (ssse3).*/
+OD_SIMD_INLINE __m128i od_mm_abs_epi16(__m128i in) {
+  __m128i mask;
+  mask = _mm_cmpgt_epi16(_mm_setzero_si128(), in);
+  return _mm_sub_epi16(_mm_xor_si128(in, mask), mask);
+}
+
 void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
  int bstride, int threshold, int dir) {
   int i;
@@ -87,7 +93,7 @@ void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
       p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride +
        offset[k]]), row);
       /* if (abs(p0) < threshold) sum += taps[k]*p0; */
-      cmp0 = _mm_cmplt_epi16(_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
+      cmp0 = _mm_cmplt_epi16(od_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
       p0 = _mm_mullo_epi16(p0, _mm_set1_epi16(taps[k]));
       p0 = _mm_and_si128(p0, cmp0);
       sum = _mm_add_epi16(sum, p0);
@@ -96,7 +102,7 @@ void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
       p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride -
        offset[k]]), row);
       /* if (abs(p1) < threshold) sum += taps[k]*p1; */
-      cmp1 = _mm_cmplt_epi16(_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
+      cmp1 = _mm_cmplt_epi16(od_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
       p1 = _mm_mullo_epi16(p1, _mm_set1_epi16(taps[k]));
       p1 = _mm_and_si128(p1, cmp1);
       sum = _mm_add_epi16(sum, p1);
@@ -132,7 +138,7 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
       p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride +
        offset[k]]), row);
       /* if (abs(p0) < threshold) sum += taps[k]*p0; */
-      cmp0 = _mm_cmplt_epi16(_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
+      cmp0 = _mm_cmplt_epi16(od_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
       p0 = _mm_mullo_epi16(p0, _mm_set1_epi16(taps[k]));
       p0 = _mm_and_si128(p0, cmp0);
       sum = _mm_add_epi16(sum, p0);
@@ -141,7 +147,7 @@ void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
       p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride -
        offset[k]]), row);
       /* if (abs(p1) < threshold) sum += taps[k]*p1; */
-      cmp1 = _mm_cmplt_epi16(_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
+      cmp1 = _mm_cmplt_epi16(od_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
       p1 = _mm_mullo_epi16(p1, _mm_set1_epi16(taps[k]));
       p1 = _mm_and_si128(p1, cmp1);
       sum = _mm_add_epi16(sum, p1);

--- a/src/x86/x86filter.c
+++ b/src/x86/x86filter.c
@@ -1,0 +1,142 @@
+/*Daala video codec
+Copyright (c) 2013 Daala project contributors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+
+#if defined(HAVE_CONFIG_H)
+# include "config.h"
+#endif
+
+#include "x86enc.h"
+#include "cpu.h"
+
+#if defined(OD_X86ASM)
+#include <stdio.h>
+#include <emmintrin.h>
+#include <pmmintrin.h>
+#include <tmmintrin.h>
+#include "../filter.h"
+
+#if defined(OD_CHECKASM)
+void od_filter_dering_direction_check(int16_t *y, int ystride, int16_t *in,
+ int bstride, int log_n, int threshold, int dir) {
+  int16_t dst[OD_BSIZE_MAX*OD_BSIZE_MAX];
+  od_filter_dering_direction_c(dst, OD_BSIZE_MAX, in, bstride, log_n, threshold, dir);
+  int i;
+  int j;
+  int failed;
+  int n = 1 << log_n;
+  failed = 0;
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (dst[i*OD_BSIZE_MAX + j] != y[i*ystride + j]) {
+        fprintf(stderr,"ASM mismatch: 0x%02X!=0x%02X @ (%2i,%2i)\n",
+         dst[i*OD_BSIZE_MAX + j],y[i*ystride + j],i,j);
+        failed = 1;
+      }
+    }
+  }
+  if (failed) {
+    fprintf(stderr, "od_filter_dering_direction check failed.\n");
+  }
+}
+#endif
+
+typedef void (*od_filter_dering_direction_fixed_func)(int16_t *y, int ystride,
+ int16_t *in, int bstride, int threshold, int dir);
+
+void print_epi16(const char * name, __m128i var){
+  int16_t *val = (int16_t*) &var;
+  fprintf(stderr, "%8s int16_t: %4i %4i %4i %4i %4i %4i %4i %4i \n",
+   name, val[0], val[1], val[2], val[3], val[4], val[5],
+   val[6], val[7]);
+}
+
+void od_filter_dering_direction_4x4(int16_t *y, int ystride, int16_t *in,
+ int bstride, int threshold, int dir) {
+  od_filter_dering_direction_c(y, ystride, in, bstride, 2, threshold, dir);
+}
+
+void od_filter_dering_direction_8x8(int16_t *y, int ystride, int16_t *in,
+ int bstride, int threshold, int dir) {
+  int i;
+  int k;
+  static const int taps[3] = {3, 2, 2};
+  int offset[3];
+  __m128i sum;
+  __m128i p0;
+  __m128i cmp0;
+  __m128i p1;
+  __m128i cmp1;
+  __m128i row;
+  __m128i res;
+  od_filter_dering_direction_offsets(offset, dir, bstride);
+  for (i = 0; i < 8; i++) {
+    sum = _mm_set1_epi16(0);
+    row = _mm_loadu_si128((__m128i*)&in[i*bstride]);
+    for (k = 0; k < 3; k++) {
+      /* p0 = in[i*bstride + j + offset[k]] - row */;
+      p0 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride + offset[k]]), row);
+      /* if (abs(p0) < threshold) sum += taps[k]*p0; */
+      cmp0 = _mm_cmplt_epi16(_mm_abs_epi16(p0), _mm_set1_epi16(threshold));
+      p0 = _mm_mullo_epi16(p0, _mm_set1_epi16(taps[k]));
+      p0 = _mm_and_si128(p0, cmp0);
+      sum = _mm_add_epi16(sum, p0);
+
+      /* p0 = in[i*bstride + j + offset[k]] - row */;
+      p1 = _mm_sub_epi16(_mm_loadu_si128((__m128i*)&in[i*bstride - offset[k]]), row);
+      /* if (abs(p1) < threshold) sum += taps[k]*p1; */
+      cmp1 = _mm_cmplt_epi16(_mm_abs_epi16(p1), _mm_set1_epi16(threshold));
+      p1 = _mm_mullo_epi16(p1, _mm_set1_epi16(taps[k]));
+      p1 = _mm_and_si128(p1, cmp1);
+      sum = _mm_add_epi16(sum, p1);
+    }
+    /* res = row + ((sum + 8) >> 4) */
+    res = sum;
+    res = _mm_add_epi16(res, _mm_set1_epi16(8));
+    res = _mm_srai_epi16(res, 4);
+    res = _mm_add_epi16(res, row);
+    _mm_storeu_si128((__m128i*)&y[i*ystride], res);
+  }
+}
+
+void od_filter_dering_direction_16x16(int16_t *y, int ystride, int16_t *in,
+ int bstride, int threshold, int dir) {
+  od_filter_dering_direction_c(y, ystride, in, bstride, 16, threshold, dir);
+}
+
+void od_filter_dering_direction_sse2(int16_t *y, int ystride, int16_t *in,
+ int bstride, int log_n, int threshold, int dir) {
+  static const od_filter_dering_direction_fixed_func VTBL[5] = {
+    NULL,
+    NULL,
+    od_filter_dering_direction_4x4,
+    od_filter_dering_direction_8x8,
+    od_filter_dering_direction_16x16
+  };
+  VTBL[log_n](y, ystride, in, bstride, threshold, dir);
+#if defined(OD_CHECKASM)
+  od_filter_dering_direction_check(y, ystride, in, bstride, log_n, threshold, dir);
+#endif
+}
+
+#endif

--- a/src/x86/x86int.h
+++ b/src/x86/x86int.h
@@ -41,6 +41,8 @@ void od_mc_blend_full8_sse2(unsigned char *_dst,int _dystride,
  const unsigned char *_src[4],int _log_xblk_sz,int _log_yblk_sz);
 void od_mc_blend_full_split8_sse2(unsigned char *_dst,int _dystride,
  const unsigned char *_src[4],int _c,int _s,int _log_xblk_sz,int _log_yblk_sz);
+void od_filter_dering_direction_sse2(int16_t *y, int ystride, int16_t *in,
+ int bstride, int log_n, int threshold, int dir);
 void od_bin_fdct4x4_sse2(od_coeff *y, int ystride,
  const od_coeff *x, int xstride);
 void od_bin_fdct4x4_sse41(od_coeff *y, int ystride,

--- a/src/x86/x86int.h
+++ b/src/x86/x86int.h
@@ -42,7 +42,7 @@ void od_mc_blend_full8_sse2(unsigned char *_dst,int _dystride,
 void od_mc_blend_full_split8_sse2(unsigned char *_dst,int _dystride,
  const unsigned char *_src[4],int _c,int _s,int _log_xblk_sz,int _log_yblk_sz);
 void od_filter_dering_direction_sse2(int16_t *y, int ystride, int16_t *in,
- int bstride, int log_n, int threshold, int dir);
+ int log_n, int threshold, int dir);
 void od_bin_fdct4x4_sse2(od_coeff *y, int ystride,
  const od_coeff *x, int xstride);
 void od_bin_fdct4x4_sse41(od_coeff *y, int ystride,

--- a/src/x86/x86int.h
+++ b/src/x86/x86int.h
@@ -42,7 +42,7 @@ void od_mc_blend_full8_sse2(unsigned char *_dst,int _dystride,
 void od_mc_blend_full_split8_sse2(unsigned char *_dst,int _dystride,
  const unsigned char *_src[4],int _c,int _s,int _log_xblk_sz,int _log_yblk_sz);
 void od_filter_dering_direction_sse2(int16_t *y, int ystride, int16_t *in,
- int log_n, int threshold, int dir);
+ int ln, int threshold, int dir);
 void od_bin_fdct4x4_sse2(od_coeff *y, int ystride,
  const od_coeff *x, int xstride);
 void od_bin_fdct4x4_sse41(od_coeff *y, int ystride,

--- a/src/x86/x86int.h
+++ b/src/x86/x86int.h
@@ -43,6 +43,8 @@ void od_mc_blend_full_split8_sse2(unsigned char *_dst,int _dystride,
  const unsigned char *_src[4],int _c,int _s,int _log_xblk_sz,int _log_yblk_sz);
 void od_filter_dering_direction_sse2(int16_t *y, int ystride, int16_t *in,
  int ln, int threshold, int dir);
+void od_filter_dering_orthogonal_sse2(int16_t *y, int ystride, int16_t *in,
+ int16_t *x, int xstride, int ln, int threshold, int dir);
 void od_bin_fdct4x4_sse2(od_coeff *y, int ystride,
  const od_coeff *x, int xstride);
 void od_bin_fdct4x4_sse41(od_coeff *y, int ystride,

--- a/src/x86/x86state.c
+++ b/src/x86/x86state.c
@@ -51,6 +51,7 @@ void od_state_opt_vtbl_init_x86(od_state *_state){
     _state->opt_vtbl.idct_2d[0] = od_bin_idct4x4_sse2;
     _state->opt_vtbl.fdct_2d[1] = od_bin_fdct8x8_sse2;
     _state->opt_vtbl.idct_2d[1] = od_bin_idct8x8_sse2;
+    _state->opt_vtbl.filter_dering_direction = od_filter_dering_direction_sse2;
 #endif
 #if defined(OD_SSE41_INTRINSICS)
     if (_state->cpu_flags&OD_CPU_X86_SSE4_1) {

--- a/src/x86/x86state.c
+++ b/src/x86/x86state.c
@@ -52,6 +52,7 @@ void od_state_opt_vtbl_init_x86(od_state *_state){
     _state->opt_vtbl.fdct_2d[1] = od_bin_fdct8x8_sse2;
     _state->opt_vtbl.idct_2d[1] = od_bin_idct8x8_sse2;
     _state->opt_vtbl.filter_dering_direction = od_filter_dering_direction_sse2;
+    _state->opt_vtbl.filter_dering_orthogonal = od_filter_dering_orthogonal_sse2;
 #endif
 #if defined(OD_SSE41_INTRINSICS)
     if (_state->cpu_flags&OD_CPU_X86_SSE4_1) {

--- a/tools/gen_filter_tables.c
+++ b/tools/gen_filter_tables.c
@@ -1,0 +1,66 @@
+/*Daala video codec
+Copyright (c) 2015 Daala project contributors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+void od_filter_dering_direction_offsets(int *offset, int dir, int bstride) {
+  int k;
+  int f;
+  if (dir <= 4) {
+    f = dir - 2;
+    for (k = 1; k <= 3; k++) offset[k - 1] = f*k/2*bstride + k;
+  }
+  else {
+    f = 6 - dir;
+    for (k = 1; k <= 3; k++) offset[k - 1] = k*bstride + f*k/2;
+  }
+}
+
+int main(int argc, char **argv) {
+  printf("int direction_offsets_table[16][3] = {\n");
+  int offset[3];
+  int bstride;
+  bstride = 38;
+  for (int dir = 0; dir < 16; dir++) {
+    od_filter_dering_direction_offsets(offset, dir, bstride);
+    printf("  {");
+    for (int i = 0; i < 3; i++) {
+      printf("%4i", offset[i]);
+      if (i < 2) {
+        printf(",");
+      }
+    }
+    printf(" }");
+    if (dir < 15) {
+      printf(",\n");
+    }
+  }
+  printf("\n};\n");
+}

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -148,7 +148,7 @@ zigzag64.c \
 $(if $(findstring -DOD_X86ASM,${CFLAGS}), \
 x86/cpu.c \
 x86/sse2mc.c \
-x86/x86filter.c \
+x86/sse2filter.c \
 x86/x86state.c \
 ) \
 $(if $(findstring -DOD_LOGGING_ENABLED,${CFLAGS}), \

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -148,6 +148,7 @@ zigzag64.c \
 $(if $(findstring -DOD_X86ASM,${CFLAGS}), \
 x86/cpu.c \
 x86/sse2mc.c \
+x86/x86filter.c \
 x86/x86state.c \
 ) \
 $(if $(findstring -DOD_LOGGING_ENABLED,${CFLAGS}), \


### PR DESCRIPTION
`od_dering` used to take up 16% of decoding time, it's now down to 10%. This code uses `_mm_abs_epi16` which is only available in SSE3, @tterribe any thoughts  on how to to do this in SSE2?