### PR TITLE
Color performance adjusted quantizer scaling

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -639,7 +639,8 @@ static void od_decode_haar_dc_sb(daala_dec_ctx *dec, od_mb_dec_ctx *ctx,
   OD_ASSERT(xdec == ydec);
   if (OD_LOSSLESS(dec, pli)) dc_quant = 1;
   else {
-    dc_quant = OD_MAXI(1, dec->state.quantizer[pli]*OD_DC_RES[pli] >> 4);
+    dc_quant = OD_MAXI(1, dec->state.quantizer[pli]*
+     dec->state.pvq_qm_q4[pli][od_qm_get_index(OD_NBSIZES - 1, 0)] >> 4);
   }
   nhsb = dec->state.nhsb;
   sb_dc_mem = dec->state.sb_dc_mem[pli];
@@ -685,7 +686,8 @@ static void od_decode_haar_dc_level(daala_dec_ctx *dec, od_mb_dec_ctx *ctx, int 
   w = dec->state.frame_width >> xdec;
   if (OD_LOSSLESS(dec, pli)) dc_quant = 1;
   else {
-    dc_quant = OD_MAXI(1, dec->state.quantizer[pli]*OD_DC_RES[pli] >> 4);
+    dc_quant = OD_MAXI(1, dec->state.quantizer[pli]*
+     dec->state.pvq_qm_q4[pli][od_qm_get_index(OD_NBSIZES - 1, 0)] >> 4);
   }
   if (OD_LOSSLESS(dec, pli)) ac_quant[0] = ac_quant[1] = 1;
   else {

--- a/src/encode.c
+++ b/src/encode.c
@@ -111,18 +111,24 @@ typedef struct od_qm_entry {
 /* No interpolation, always use od_flat_qm_q4, but use a different scale for
    each plane.
    FIXME: Add interpolation and properly tune chroma. */
-static const od_qm_entry OD_DEFAULT_QMS[2][2][OD_NPLANES_MAX] = {
+static const od_qm_entry OD_DEFAULT_QMS[2][3][OD_NPLANES_MAX] = {
  /* Masking disabled */
- {{{15, 256, OD_LUMA_QM_Q4[OD_MASKING_DISABLED]},
-   {15, 448, OD_CHROMA_QM_Q4[OD_MASKING_DISABLED]},
-   {15, 320, OD_CHROMA_QM_Q4[OD_MASKING_DISABLED]}},
+ {{{4, 256, OD_LUMA_QM_Q4[OD_MASKING_DISABLED]},
+   {4, 448, OD_CHROMA_QM_Q4[OD_MASKING_DISABLED]},
+   {4, 320, OD_CHROMA_QM_Q4[OD_MASKING_DISABLED]}},
+  {{318, 256, OD_LUMA_QM_Q4[OD_MASKING_DISABLED]},
+   {318, 140, OD_CHROMA_QM_Q4[OD_MASKING_DISABLED]},
+   {318, 100, OD_CHROMA_QM_Q4[OD_MASKING_DISABLED]}},
   {{0, 0, NULL},
    {0, 0, NULL},
    {0, 0, NULL}}},
  /* Masking enabled */
- {{{15, 256, OD_LUMA_QM_Q4[OD_MASKING_ENABLED]},
-   {15, 448, OD_CHROMA_QM_Q4[OD_MASKING_ENABLED]},
-   {15, 320, OD_CHROMA_QM_Q4[OD_MASKING_ENABLED]}},
+ {{{4, 256, OD_LUMA_QM_Q4[OD_MASKING_ENABLED]},
+   {4, 448, OD_CHROMA_QM_Q4[OD_MASKING_ENABLED]},
+   {4, 320, OD_CHROMA_QM_Q4[OD_MASKING_ENABLED]}},
+  {{318, 256, OD_LUMA_QM_Q4[OD_MASKING_ENABLED]},
+   {318, 140, OD_CHROMA_QM_Q4[OD_MASKING_ENABLED]},
+   {318, 100, OD_CHROMA_QM_Q4[OD_MASKING_ENABLED]}},
   {{0, 0, NULL},
    {0, 0, NULL},
    {0, 0, NULL}}}
@@ -1304,7 +1310,8 @@ static void od_quantize_haar_dc_sb(daala_enc_ctx *enc, od_mb_enc_ctx *ctx,
   OD_ASSERT(xdec == ydec);
   if (OD_LOSSLESS(enc, pli)) dc_quant = 1;
   else {
-    dc_quant = OD_MAXI(1, enc->state.quantizer[pli]*OD_DC_RES[pli] >> 4);
+    dc_quant = OD_MAXI(1, enc->state.quantizer[pli]*
+     enc->state.pvq_qm_q4[pli][od_qm_get_index(OD_NBSIZES - 1, 0)] >> 4);
   }
   nhsb = enc->state.nhsb;
   sb_dc_mem = enc->state.sb_dc_mem[pli];
@@ -1351,7 +1358,8 @@ static void od_quantize_haar_dc_level(daala_enc_ctx *enc, od_mb_enc_ctx *ctx,
   w = enc->state.frame_width >> xdec;
   if (OD_LOSSLESS(enc, pli)) dc_quant = 1;
   else {
-    dc_quant = OD_MAXI(1, enc->state.quantizer[pli]*OD_DC_RES[pli] >> 4);
+    dc_quant = OD_MAXI(1, enc->state.quantizer[pli]*
+     enc->state.pvq_qm_q4[pli][od_qm_get_index(OD_NBSIZES - 1, 0)] >> 4);
   }
   if (OD_LOSSLESS(enc, pli)) ac_quant[0] = ac_quant[1] = 1;
   else {

--- a/src/state.c
+++ b/src/state.c
@@ -37,13 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #endif
 #include "block_size.h"
 
-/* OD_DC_RES[i] adjusts the quantization of DC for the ith plane.
-   These values are based on manual tuning to optimize PSNR-HVS, while also
-   attempting to keep a good visual balance between the relative resolution
-   of luma, and chroma.
-   FIXME: Tune this properly, see also OD_DEFAULT_QMS.*/
-const od_coeff OD_DC_RES[3] = {17, 24, 17};
-
 /* Scaling compensation for the Haar equivalent basis function. Left is
    for horizontal/vertical. Right is for diagonal. */
 #if OD_DISABLE_FILTER || OD_DEBLOCKING

--- a/src/state.h
+++ b/src/state.h
@@ -40,8 +40,6 @@ typedef struct od_adapt_ctx      od_adapt_ctx;
 # include "util.h"
 # include "intra.h"
 
-extern const od_coeff OD_DC_RES[3];
-
 extern const od_coeff OD_DC_QM[OD_NBSIZES - 1][2];
 
 extern const int OD_HAAR_QM[2][OD_LOG_BSIZE_MAX];


### PR DESCRIPTION
This change is relevant to issue #8. Commit https://github.com/barrbrain/daala/commit/6066bf0f30ee62e69f46f758f35d05293f39b485 - Use 3/4 of the existing quantizers and distribute along a quadratic curve. Subjective improvements in chroma error observed at 0.1, 0.04 and 0.02bpp. This gives an idea of how improved chroma quantization matrices should be distributed.
I made a visualization of the effect of this curve on stills in subset1:
https://youtu.be/sO0whnADzFk