### PR TITLE
Document that applications should free comments

### DIFF
--- a/include/daala/codec.h
+++ b/include/daala/codec.h
@@ -254,8 +254,8 @@ void daala_info_clear(daala_info *info);
  *  names are limited to ASCII, and treated as case-insensitive.
  * See the Daala specification for details.
  *
- * In filling in this structure, daala_decode_header() will null-terminate the
- *  user_comment strings for safety.
+ * In filling in this structure, daala_decode_header_in() will null-terminate
+ *  the user_comment strings for safety.
  * However, the bitstream format itself treats them as 8-bit clean vectors,
  *  possibly containing null characters, and so the length array should be
  *  treated as their authoritative length.*/
@@ -271,7 +271,12 @@ struct daala_comment {
   char *vendor;
 };
 
+/**Initializes a daala_comment section. Users should free the returned
+   data with daala_comment_clear().
+   \param dc A #daala_comment structure.*/
 void daala_comment_init(daala_comment *dc);
+/**Free resources allocated for metadata.
+   \param dc A #daala_comment structure.*/
 void daala_comment_clear(daala_comment *dc);
 
 int64_t daala_granule_basetime(void *encdec, int64_t granpos);

--- a/include/daala/daaladec.h
+++ b/include/daala/daaladec.h
@@ -134,6 +134,7 @@ typedef struct daala_setup_info daala_setup_info;
              The application may immediately begin using the contents of this
               structure after the second header is decoded, though it must
               continue to be passed in on all subsequent calls.
+             Users should free the returned data with daala_comment_clear().
  * \param ds A pointer to a daala_setup_info pointer to fill in.
              The contents of this pointer must be initialized to <tt>NULL</tt>
               on the first call, and the returned value must continue to be

--- a/include/daala/daalaenc.h
+++ b/include/daala/daalaenc.h
@@ -64,6 +64,7 @@ typedef struct daala_enc_ctx daala_enc_ctx;
  *   - Submit the compressed frame via daala_encode_img_in().
  *   - Repeatedly call daala_encode_packet_out() to retrieve any video data
  *      packets that are ready.
+ * - Call daala_comment_clear() to release all comments allocated.
  * - Call daala_encode_free() to release all encoder memory.*/
 /*@{*/
 /**Allocates and initializes an encoder instance.
@@ -88,7 +89,8 @@ int daala_encode_ctl(daala_enc_ctx *enc,
  *  encoding actual video data.
  * \param enc A #daala_enc_ctx handle.
  * \param comments The metadata to place in the comment header, when it is
- *                  encoded.
+ *                  encoded. Users should free the returned data with
+ *                  daala_comment_clear().
  * \param dp A <tt>daala_packet</tt> structure to fill.
  *           All of the elements of this structure will be set,
  *            including a pointer to the header data.


### PR DESCRIPTION
An alternative could be to keep a reference to the comments and let encode/decode_free() free them automatically