### PR TITLE
packet/image renames and prefix doc

### DIFF
--- a/examples/analyzer.cc
+++ b/examples/analyzer.cc
@@ -91,7 +91,7 @@ private:
   bool readPacket(ogg_packet *packet);
   bool readHeaders();
 public:
-  od_img img;
+  daala_image img;
   int frame;
 
   DaalaDecoder();
@@ -609,7 +609,7 @@ ogg_int64_t block_edge_luma(ogg_int64_t yval) {
 }
 
 void TestPanel::render() {
-  od_img *img = &dd.img;
+  daala_image *img = &dd.img;
   /* Assume both chroma planes are decimated the same */
   int xdec = img->planes[1].xdec;
   int ydec = img->planes[1].ydec;
@@ -1082,7 +1082,7 @@ void TestPanel::onMouseMotion(wxMouseEvent& event) {
   int col = mouse_x/zoom;
   if (row >= 0 && col >= 0 && row < getDecodeHeight()
    && col < getDecodeWidth()) {
-    const od_img_plane *planes = dd.img.planes;
+    const daala_image_plane *planes = dd.img.planes;
     /* Assume both chroma planes are decimated the same */
     int xdec = planes[1].xdec;
     int ydec = planes[1].ydec;

--- a/examples/dump_video.c
+++ b/examples/dump_video.c
@@ -87,7 +87,7 @@ static void sigint_handler(int signal) {
 }
 
 /*Write out the planar YUV frame, uncropped.*/
-static void video_write(FILE *outfile, od_img *img, int raw) {
+static void video_write(FILE *outfile, daala_image *img, int raw) {
   int pli;
   int i;
   if (outfile) {
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
   daala_comment dc;
   daala_setup_info *ds;
   daala_dec_ctx *dd;
-  od_img img;
+  daala_image img;
   const char *optstring = "o:r";
   struct option options [] = {
    { "output", required_argument, NULL, 'o' },

--- a/examples/encoder_example.c
+++ b/examples/encoder_example.c
@@ -57,7 +57,7 @@ struct av_input{
   char video_chroma_type[16];
   int video_nplanes;
   daala_plane_info video_plane_info[OD_NPLANES_MAX];
-  od_img video_img;
+  daala_image video_img;
   int video_cur_img;
   int video_depth;
   int video_swapendian;
@@ -171,7 +171,7 @@ static int y4m_parse_tags(av_input *avin, char *tags) {
 }
 
 static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
-  od_img *img;
+  daala_image *img;
   unsigned char buf[128];
   int ret;
   int pli;
@@ -374,7 +374,7 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
   img->width = avin->video_pic_w;
   img->height = avin->video_pic_h;
   for (pli = 0; pli < img->nplanes; pli++) {
-    od_img_plane *iplane;
+    daala_image_plane *iplane;
     iplane = img->planes + pli;
     iplane->xdec = avin->video_plane_info[pli].xdec;
     iplane->ydec = avin->video_plane_info[pli].ydec;
@@ -430,7 +430,7 @@ static int fetch(av_input *avin, int *limit, int *skip) {
   for (;;) {
     size_t ret;
     char frame[6];
-    od_img *img;
+    daala_image *img;
     int pli;
     ret = fread(frame, 1, 6, avin->video_infile);
     if (ret != 6) {
@@ -454,7 +454,7 @@ static int fetch(av_input *avin, int *limit, int *skip) {
     /*Read the frame data.*/
     img = &avin->video_img;
     for (pli = 0; pli < img->nplanes; pli++) {
-      od_img_plane *iplane;
+      daala_image_plane *iplane;
       int bytes;
       size_t plane_sz;
       iplane = &img->planes[pli];

--- a/examples/player_example.c
+++ b/examples/player_example.c
@@ -51,7 +51,7 @@ typedef struct {
   ogg_stream_state os;
   daala_dec_ctx *dctx;
   SDL_Texture *texture;
-  od_img img;
+  daala_image img;
   int width;
   int height;
   int done;
@@ -89,7 +89,7 @@ enum {
 };
 
 static void img_to_rgb(player_example *player, SDL_Texture *tex,
- const od_img *img, int plane_mask);
+ const daala_image *img, int plane_mask);
 static int next_plane(int plane_mask);
 static void wait_to_refresh(uint32_t *previous_ticks, uint32_t ms_per_frame);
 
@@ -587,7 +587,7 @@ void build_yuv_to_rgb_table(player_example *player) {
 }
 
 void img_to_rgb(player_example *player, SDL_Texture *texture,
- const od_img *img, int plane_mask) {
+ const daala_image *img, int plane_mask) {
   unsigned char *y_row;
   unsigned char *cb_row;
   unsigned char *cr_row;
@@ -620,7 +620,7 @@ void img_to_rgb(player_example *player, SDL_Texture *texture,
     exit(1);
   }
   /*The texture memory is only allocated for the cropped frame.  The
-    od_img is rounded up to superblock. */
+    daala_image is rounded up to superblock. */
   if(SDL_QueryTexture(texture, NULL, NULL, &width, &height)){
     fprintf(stderr, "Couldn't query video texture!");
     exit(1);

--- a/include/daala/codec.h
+++ b/include/daala/codec.h
@@ -124,8 +124,8 @@ extern "C" {
 /**The maximum number of color planes allowed in a single frame.*/
 # define OD_NPLANES_MAX (4)
 
-typedef struct od_img_plane od_img_plane;
-typedef struct od_img od_img;
+typedef struct daala_image_plane daala_image_plane;
+typedef struct daala_image daala_image;
 typedef struct daala_plane_info daala_plane_info;
 typedef struct daala_info daala_info;
 typedef struct daala_comment daala_comment;
@@ -143,7 +143,7 @@ const char *daala_version_string(void);
 int daala_log_init(void);
 
 /** Representation of a single component within an image or frame. */
-struct od_img_plane {
+struct daala_image_plane {
   /** Image data is stored as an unsigned octet type whether it's
       actually 8 bit or a multi-byte depth. */
   unsigned char *data;
@@ -172,9 +172,9 @@ struct od_img_plane {
 };
 
 /** Representation of an image or video frame. */
-struct od_img {
+struct daala_image {
   /** Typical 3 planes for Y, Cb, and  Cr. Can have a 4th plane for alpha */
-  od_img_plane planes[OD_NPLANES_MAX];
+  daala_image_plane planes[OD_NPLANES_MAX];
   /** Number of planes (1 for greyscale, 3 for YCbCr, 4 for YCbCr+Alpha ) */
   int nplanes;
   /** Width and height in pixels */

--- a/include/daala/daaladec.h
+++ b/include/daala/daaladec.h
@@ -38,8 +38,8 @@ extern "C" {
 #define OD_DECCTL_SET_BSIZE_BUFFER (7001)
 #define OD_DECCTL_SET_FLAGS_BUFFER (7003)
 #define OD_DECCTL_SET_MV_BUFFER    (7005)
-/** Copy the motion compensated reference into a user supplied od_img.
- * \param[in]  <tt>od_img*</tt>: Pointer to the user supplied od_img.
+/** Copy the motion compensated reference into a user supplied daala_image.
+ * \param[in]  <tt>daala_image*</tt>: Pointer to the user supplied daala_image.
  *              Image must be allocated by the caller, and must be the
  *              same format as the decoder output images. */
 #define OD_DECCTL_SET_MC_IMG       (7007)
@@ -195,7 +195,7 @@ int daala_decode_packet_in(daala_dec_ctx *dec, const daala_packet *dp);
  * \retval 0 No image was available, so the contents of \a img were left
  *            unchanged.
  * \retval OD_EFAULT One of \a dec or \a img was <tt>NULL</tt>.*/
-int daala_decode_img_out(daala_dec_ctx *dec, od_img *img);
+int daala_decode_img_out(daala_dec_ctx *dec, daala_image *img);
 
 /*@}*/
 

--- a/include/daala/daalaenc.h
+++ b/include/daala/daalaenc.h
@@ -113,7 +113,7 @@ int daala_encode_flush_header(daala_enc_ctx *enc,
  * \retval OD_EINVAL The image size does not match the frame size the encoder
  *                   was initialized with, or encoding has already
  *                    completed.*/
-int daala_encode_img_in(daala_enc_ctx *enc, od_img *img, int duration);
+int daala_encode_img_in(daala_enc_ctx *enc, daala_image *img, int duration);
 /**Retrieves encoded video data packets.
  * This should be called repeatedly after each frame is submitted to flush any
  *  encoded packets, until it returns 0.

--- a/src/decint.h
+++ b/src/decint.h
@@ -47,9 +47,9 @@ struct daala_dec_ctx {
   unsigned int *user_flags;
   int user_fstride;
   od_mv_grid_pt *user_mv_grid;
-  od_img *user_mc_img;
+  daala_image *user_mc_img;
   /*Buffer for the output frames, bitdepth equal to declared video depth.*/
-  od_img output_img[2];
+  daala_image output_img[2];
   unsigned char *output_img_data;
   /*Frame counter in decoding order.*/
   int64_t dec_order_count;

--- a/src/decode.c
+++ b/src/decode.c
@@ -46,8 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 
 static int od_dec_init(od_dec_ctx *dec, const daala_info *info,
  const daala_setup_info *setup) {
-  od_img *img;
-  od_img_plane *iplane;
+  daala_image *img;
+  daala_image_plane *iplane;
   size_t data_sz;
   unsigned char *output_img_data;
   int frame_buf_width;
@@ -180,7 +180,7 @@ int daala_decode_ctl(daala_dec_ctx *dec, int req, void *buf, size_t buf_sz) {
     case OD_DECCTL_SET_MC_IMG : {
       OD_RETURN_CHECK(dec, OD_EFAULT);
       OD_RETURN_CHECK(buf, OD_EFAULT);
-      OD_RETURN_CHECK((buf_sz == sizeof(od_img)), OD_EINVAL);
+      OD_RETURN_CHECK((buf_sz == sizeof(daala_image)), OD_EINVAL);
       dec->user_mc_img = buf;
       return OD_SUCCESS;
     }
@@ -217,7 +217,7 @@ int daala_decode_ctl(daala_dec_ctx *dec, int req, void *buf, size_t buf_sz) {
   }
 }
 
-static void od_dec_blank_img(od_img *img) {
+static void od_dec_blank_img(daala_image *img) {
   int pli;
   int frame_buf_height;
   frame_buf_height = img->height + (OD_BUFFER_PADDING << 1);
@@ -872,7 +872,7 @@ static void od_dec_mv_unpack(daala_dec_ctx *dec, int num_refs) {
   int nvmvbs;
   int vx;
   int vy;
-  od_img *img;
+  daala_image *img;
   int width;
   int height;
   int mv_res;
@@ -975,7 +975,7 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
   int nhdr;
   int nvdr;
   od_state *state;
-  od_img *rec;
+  daala_image *rec;
   state = &dec->state;
   /*Initialize the data needed for each plane.*/
   nplanes = state->info.nplanes;
@@ -1159,7 +1159,7 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
 int daala_decode_packet_in(daala_dec_ctx *dec, const daala_packet *op) {
   int refi;
   od_mb_dec_ctx mbctx;
-  od_img *ref_img;
+  daala_image *ref_img;
   int frame_type;
   if (dec == NULL || op == NULL) return OD_EFAULT;
   if (dec->packet_state != OD_PACKET_DATA) return OD_EINVAL;
@@ -1293,7 +1293,7 @@ int daala_decode_packet_in(daala_dec_ctx *dec, const daala_packet *op) {
   return 0;
 }
 
-int daala_decode_img_out(daala_dec_ctx *dec, od_img *img) {
+int daala_decode_img_out(daala_dec_ctx *dec, daala_image *img) {
   int curr_dec_output;
   if (dec == NULL || img == NULL) return OD_EFAULT;
   curr_dec_output = -1;

--- a/src/encint.h
+++ b/src/encint.h
@@ -94,7 +94,7 @@ struct od_params_ctx {
 };
 
 struct od_input_frame {
-  od_img *img;
+  daala_image *img;
   int duration;
   int type;
   int number;
@@ -105,7 +105,7 @@ struct od_input_queue {
   unsigned char *input_img_data;
 
   /* Circular queue of frame input images in display order. */
-  od_img images[OD_MAX_REORDER];
+  daala_image images[OD_MAX_REORDER];
   int duration[OD_MAX_REORDER];
   int input_head;
   int input_size;
@@ -166,7 +166,7 @@ struct daala_enc_ctx{
       P-frame specified by enc->b_frames.*/
   od_input_queue input_queue;
   /* A pointer to the currently encoding image. */
-  od_img *curr_img;
+  daala_image *curr_img;
   /** Frame delay. */
   int frame_delay;
   /** Displaying order of current frame being encoded. */
@@ -180,8 +180,8 @@ struct daala_enc_ctx{
 #endif
 #if defined(OD_DUMP_IMAGES)
   unsigned char *dump_img_data;
-  od_img vis_img;
-  od_img tmp_vis_img;
+  daala_image vis_img;
+  daala_image tmp_vis_img;
   unsigned char *upsample_line_buf[8];
 # if defined(OD_ANIMATE)
   int ani_iter;
@@ -250,7 +250,7 @@ void od_enc_opt_vtbl_init_c(od_enc_ctx *enc);
 
 # if defined(OD_DUMP_IMAGES)
 void od_encode_fill_vis(daala_enc_ctx *enc);
-void od_img_draw_line(od_img *img, int x0, int y0, int x1, int y1,
+void daala_image_draw_line(daala_image *img, int x0, int y0, int x1, int y1,
  const unsigned char ycbcr[3]);
 void od_state_draw_mvs(daala_enc_ctx *enc);
 # endif

--- a/src/mcenc.c
+++ b/src/mcenc.c
@@ -1615,7 +1615,7 @@ int32_t od_mc_compute_satd16_64x64_c(const unsigned char *src, int systride,
 static int32_t od_enc_sad(od_enc_ctx *enc, const unsigned char *p,
  int pystride, int pxstride, int pli, int x, int y, int log_blk_sz) {
   od_state *state;
-  od_img_plane *iplane;
+  daala_image_plane *iplane;
   unsigned char *src;
   int clipx;
   int clipy;
@@ -1682,7 +1682,7 @@ static int32_t od_enc_sad(od_enc_ctx *enc, const unsigned char *p,
 static int32_t od_enc_satd(od_enc_ctx *enc, const unsigned char *p,
  int pystride, int pxstride, int pli, int x, int y, int log_blk_sz) {
   od_state *state;
-  od_img_plane *iplane;
+  daala_image_plane *iplane;
   unsigned char *src;
   int clipx;
   int clipy;
@@ -2235,7 +2235,7 @@ static int32_t od_mv_est_bma_sad(od_mv_est_ctx *est,
   ret = 0;
   planes = (est->flags & OD_MC_USE_CHROMA) ? 3 : 1;
   for (pli = 0; pli < planes; pli++) {
-    od_img_plane *iplane;
+    daala_image_plane *iplane;
     unsigned char *ref_img;
     int dist_scale;
     dist_scale = pli > 0 ? OD_MC_CHROMA_SCALE : 0;
@@ -2688,7 +2688,7 @@ static void od_mv_est_init_mv(od_mv_est_ctx *est, int ref, int vx, int vy,
   od_mv_est_clear_hit_cache(est);
 #if defined(OD_DUMP_IMAGES) && defined(OD_ANIMATE)
   if (animating) {
-    od_img_draw_line(&est->enc->vis_img, x0, y0,
+    daala_image_draw_line(&est->enc->vis_img, x0, y0,
      x0 + candx, y0 + candy, OD_YCbCr_MVCAND);
   }
 #endif
@@ -2773,7 +2773,7 @@ static void od_mv_est_init_mv(od_mv_est_ctx *est, int ref, int vx, int vy,
       od_mv_est_set_hit(est, candx, candy);
 #if defined(OD_DUMP_IMAGES) && defined(OD_ANIMATE)
       if (animating) {
-        od_img_draw_line(&est->enc->vis_img, x0, y0,
+        daala_image_draw_line(&est->enc->vis_img, x0, y0,
          x0 + candx, y0 + candy, OD_YCbCr_MVCAND);
       }
 #endif
@@ -2824,7 +2824,7 @@ static void od_mv_est_init_mv(od_mv_est_ctx *est, int ref, int vx, int vy,
         od_mv_est_set_hit(est, candx, candy);
 #if defined(OD_DUMP_IMAGES) && defined(OD_ANIMATE)
         if (animating) {
-          od_img_draw_line(&est->enc->vis_img, x0, y0,
+          daala_image_draw_line(&est->enc->vis_img, x0, y0,
            x0 + candx, y0 + candy, OD_YCbCr_MVCAND);
         }
 #endif
@@ -2883,7 +2883,7 @@ static void od_mv_est_init_mv(od_mv_est_ctx *est, int ref, int vx, int vy,
             od_mv_est_set_hit(est, candx, candy);
 #if defined(OD_DUMP_IMAGES) && defined(OD_ANIMATE)
             if (animating) {
-              od_img_draw_line(&est->enc->vis_img, x0, y0,
+              daala_image_draw_line(&est->enc->vis_img, x0, y0,
                x0 + candx, y0 + candy, OD_YCbCr_MVCAND);
             }
 #endif
@@ -4666,21 +4666,21 @@ static void od_mv_dp_animate_encode(od_enc_ctx *enc,
         d1vy = dp[1].mv->vy;
         x1 = (d1vx << (OD_LOG_MVBSIZE_MIN + 1)) + (OD_BUFFER_PADDING << 1);
         y1 = (d1vy << (OD_LOG_MVBSIZE_MIN + 1)) + (OD_BUFFER_PADDING << 1);
-        od_img_draw_line(&enc->vis_img, x0, y0, x1, y1, OD_YCbCr_EDGE);
+        daala_image_draw_line(&enc->vis_img, x0, y0, x1, y1, OD_YCbCr_EDGE);
         if (d1vx - d0vx > 1) {
           mvb_sz = d1vx - d0vx;
           if (!has_gap || dp + 1 != dp0) mvb_sz >>= 1;
           if (!state->mv_grid[d0vy][d0vx + mvb_sz].valid) {
             if (d0vy >= mvb_sz
              && state->mv_grid[d0vy - mvb_sz][d0vx + mvb_sz].valid) {
-              od_img_draw_line(&enc->vis_img,
+              daala_image_draw_line(&enc->vis_img,
                x0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                y0 - (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                x0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)), y1, OD_YCbCr_EDGE);
             }
             if (dp[0].mv->vy <= state->nvmvbs - mvb_sz
              && state->mv_grid[d0vy + mvb_sz][d0vx + mvb_sz].valid) {
-              od_img_draw_line(&enc->vis_img,
+              daala_image_draw_line(&enc->vis_img,
                x0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                y0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                x0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)), y1, OD_YCbCr_EDGE);
@@ -4693,14 +4693,14 @@ static void od_mv_dp_animate_encode(od_enc_ctx *enc,
           if (!state->mv_grid[d0vy + mvb_sz][d0vx].valid) {
             if (d0vx >= mvb_sz
              && state->mv_grid[d0vy + mvb_sz][d0vx - mvb_sz].valid) {
-              od_img_draw_line(&enc->vis_img,
+              daala_image_draw_line(&enc->vis_img,
                x0 - (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                y0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                x1, y0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)), OD_YCbCr_EDGE);
             }
             if (d0vx <= state->nhmvbs - mvb_sz
              && state->mv_grid[d0vy + mvb_sz][d0vx + mvb_sz].valid) {
-              od_img_draw_line(&enc->vis_img,
+              daala_image_draw_line(&enc->vis_img,
                x0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                y0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)),
                x1, y0 + (mvb_sz << (OD_LOG_MVBSIZE_MIN + 1)), OD_YCbCr_EDGE);
@@ -4746,7 +4746,7 @@ static void od_mv_dp_animate_encode(od_enc_ctx *enc,
         y0 = (d1vy << (OD_LOG_MVBSIZE_MIN + 1)) + (OD_BUFFER_PADDING << 1);
         for (si = 0; si < nactive_states; si++) {
           dp_state = active_states[si];
-          od_img_draw_line(&enc->vis_img, x0, y0,
+          daala_image_draw_line(&enc->vis_img, x0, y0,
            x0 + OD_DIV_ROUND_POW2(dp[1].states[dp_state].mv[0], 2, 2),
            y0 + OD_DIV_ROUND_POW2(dp[1].states[dp_state].mv[1], 2, 2),
            OD_YCbCr_MVCAND);
@@ -4775,7 +4775,7 @@ static void od_mv_dp_animate_encode(od_enc_ctx *enc,
   y0 = (d1vy << (OD_LOG_MVBSIZE_MIN + 1)) + (OD_BUFFER_PADDING << 1);
   for (si = 0; si < nactive_states; si++) {
     dp_state = active_states[si];
-    od_img_draw_line(&enc->vis_img, x0, y0,
+    daala_image_draw_line(&enc->vis_img, x0, y0,
      x0 + OD_DIV_ROUND_POW2(dp[1].states[dp_state].mv[0], 2, 2),
      y0 + OD_DIV_ROUND_POW2(dp[1].states[dp_state].mv[1], 2, 2),
      OD_YCbCr_MVCAND);
@@ -6382,7 +6382,7 @@ void od_mv_subpel_refine(od_mv_est_ctx *est, int cost_thresh) {
 
 void od_mv_est(od_mv_est_ctx *est, int lambda, int num_refs) {
   od_state *state;
-  od_img_plane *iplane;
+  daala_image_plane *iplane;
   int32_t dcost;
   int cost_thresh;
   int nhmvbs;

--- a/src/state.h
+++ b/src/state.h
@@ -172,7 +172,7 @@ struct od_adapt_ctx {
 typedef struct od_output_frame od_output_frame;
 
 struct od_output_frame {
-  od_img *img;
+  daala_image *img;
   int number;
 };
 
@@ -182,7 +182,7 @@ struct od_output_queue {
   unsigned char *output_img_data;
 
   /* Circular queue of frame images in decode order. */
-  od_img images[OD_MAX_REORDER];
+  daala_image images[OD_MAX_REORDER];
   int decode_index;
   int decode_used[OD_MAX_REORDER];
 
@@ -194,7 +194,7 @@ struct od_output_queue {
 
 int od_output_queue_init(od_output_queue *out, od_state *state);
 void od_output_queue_clear(od_output_queue *out);
-int od_output_queue_add(od_output_queue *out, od_img *img, int number);
+int od_output_queue_add(od_output_queue *out, daala_image *img, int number);
 #define od_output_queue_has_next(out) \
  ((out)->output_used[(out)->output_index])
 od_output_frame *od_output_queue_next(od_output_queue *out);
@@ -211,7 +211,7 @@ struct od_state{
   int                 ref_imgi[OD_FRAME_MAX+1];
   /** Pointers to the ref images so one can move them around without coping
       them. */
-  od_img              ref_imgs[OD_FRAME_MAX+1];
+  daala_image         ref_imgs[OD_FRAME_MAX+1];
   /* ----------------------------------------------------- */
   /** I,P,B frame type of current frame. */
   int frame_type;
@@ -286,19 +286,19 @@ void od_aligned_free(void *_ptr);
 int od_state_init(od_state *_state, const daala_info *_info);
 void od_state_clear(od_state *_state);
 
-void od_img_plane_copy(od_img *dest, od_img *src, int pli);
-void od_img_copy(od_img *dest, od_img *src);
+void od_img_plane_copy(daala_image *dest, daala_image *src, int pli);
+void od_img_copy(daala_image *dest, daala_image *src);
 void od_adapt_ctx_reset(od_adapt_ctx *state, int is_keyframe);
 void od_state_set_mv_res(od_state *state, int mv_res);
 void od_state_pred_block_from_setup(od_state *state, unsigned char *buf,
  int ystride, int pli, int vx, int vy, int c, int s, int log_mvb_sz);
 void od_state_pred_block(od_state *state, unsigned char *buf,
  int ystride, int xstride, int pli, int vx, int vy, int log_mvb_sz);
-void od_state_mc_predict(od_state *state, od_img *dst);
+void od_state_mc_predict(od_state *state, daala_image *dst);
 void od_state_init_border(od_state *state);
 void od_state_init_superblock_split(od_state *state, unsigned char bsize);
-int od_state_dump_yuv(od_state *state, od_img *img, const char *tag);
-void od_img_edge_ext(od_img* src);
+int od_state_dump_yuv(od_state *state, daala_image *img, const char *tag);
+void od_img_edge_ext(daala_image* src);
 int od_state_push_output_buff_tail(od_state *state);
 int od_state_pop_output_buff_head(od_state *state);
 int od_state_pop_output_buff_tail(od_state *state);
@@ -307,15 +307,15 @@ void od_ref_buf_to_coeff(od_state *state,
  unsigned char *src, int src_xstride, int src_ystride,
  int w, int h);
 void od_ref_plane_to_coeff(od_state *state, od_coeff *dst, int lossless_p,
- od_img *src, int pli);
+ daala_image *src, int pli);
 void od_coeff_to_ref_buf(od_state *state,
  unsigned char *dst, int dst_xstride, int dst_ystride,
  od_coeff *src, int src_ystride, int lossless_p,
  int w, int h);
-void od_coeff_to_ref_plane(od_state *state, od_img *dst, int pli,
+void od_coeff_to_ref_plane(od_state *state, daala_image *dst, int pli,
  od_coeff *src, int lossless_p);
 # if defined(OD_DUMP_IMAGES)
-int od_state_dump_img(od_state *state, od_img *img, const char *tag);
+int od_state_dump_img(od_state *state, daala_image *img, const char *tag);
 # endif
 void od_init_skipped_coeffs(od_coeff *d, od_coeff *pred, int is_keyframe,
  int bo, int n, int w);

--- a/src/x86/x86state.c
+++ b/src/x86/x86state.c
@@ -49,7 +49,7 @@ void od_state_opt_vtbl_init_x86(od_state *_state){
   }
   else {
     /*8 bit assembly for those functions that work directly on 8-bit
-      od_img and reference buffers.*/
+      daala_image and reference buffers.*/
     if (_state->cpu_flags&OD_CPU_X86_SSE2) {
 #if defined(OD_GCC_INLINE_ASSEMBLY)
       _state->opt_vtbl.mc_blend_full = od_mc_blend_full8_sse2;

--- a/tools/upsample.c
+++ b/tools/upsample.c
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 static void usage(char **_argv) {
   fprintf(stderr, "Usage: %s <input> <output>\n"
    "    <input> must be a YUV4MPEG file.\n"
-   "    <output> will be <input> upsampled using od_img_upsample8.\n"
+   "    <output> will be <input> upsampled using daala_image_upsample8.\n"
    , _argv[0]);
 }
 
@@ -50,7 +50,7 @@ static const char *CHROMA_TAGS[4] = { " C420jpeg", "", " C422jpeg", " C444" };
 /*Upsamples the reconstructed image to a reference image.
   Forked version of code once used by the encoder, but is now only used
    in conditionally compiled visualization output.*/
-void upsample8(od_img *dimg, const od_img *simg) {
+void upsample8(daala_image *dimg, const daala_image *simg) {
   int i;
   int pli;
   unsigned char *line_buf[8];
@@ -65,8 +65,8 @@ void upsample8(od_img *dimg, const od_img *simg) {
     line_buf[i] = line_buf[i-1] + (buf_width << 1);
   }
   for (pli = 0; pli < simg->nplanes; pli++) {
-    const od_img_plane *siplane;
-    od_img_plane *diplane;
+    const daala_image_plane *siplane;
+    daala_image_plane *diplane;
     const unsigned char *src;
     unsigned char *dst;
     int xpad;
@@ -230,13 +230,13 @@ int main(int _argc, char **_argv) {
     video_input_ycbcr in;
     int ret = 0;
     char tag[5];
-    od_img *simg = &state.ref_imgs[1];
-    od_img *dimg = &state.ref_imgs[0];
+    daala_image *simg = &state.ref_imgs[1];
+    daala_image *dimg = &state.ref_imgs[0];
     int x, y;
     ret = video_input_fetch_frame(&vid, in, tag);
     if (ret == 0) break;
     for (pli = 0; pli < 3; pli++) {
-      od_img_plane *siplane = simg->planes + pli;
+      daala_image_plane *siplane = simg->planes + pli;
       unsigned char *src = siplane->data;
       int src_stride = siplane->ystride;
       int plane_width = simg->width >> xdec[pli];
@@ -248,7 +248,7 @@ int main(int _argc, char **_argv) {
           src[y*src_stride + x] = in[pli].data[cy*in[pli].stride + cx];
         }
       }
-      /*From od_img_plane_copy_pad8*/
+      /*From daala_image_plane_copy_pad8*/
       /*Right side.*/
       for (x = w[pli]; x < plane_width; x++) {
         src = siplane->data + x - 1;
@@ -271,7 +271,7 @@ int main(int _argc, char **_argv) {
     upsample8(dimg, simg);
     fprintf(fout, "FRAME\n");
     for (pli = 0; pli < 3; pli++) {
-      od_img_plane *diplane = dimg->planes + pli;
+      daala_image_plane *diplane = dimg->planes + pli;
       unsigned char *dst = diplane->data;
       for (y = 0; y < 2*h[pli]; y++) {
         if (fwrite(dst + diplane->ystride*y, 2*w[pli], 1, fout) < 1) {


### PR DESCRIPTION
This pr makes packets and images follow the same conventions (od underscore fullname) and adds a line to explicitly differentiate function calls and data types prefixes.

In my opinion, the coding conventions should change to allow data types to have uppercase letters (eg ODPacket and ODImage) in order to distinguish them better from function calls, but that is separate from this set.