### PR TITLE
Use an enumeration for supported bitdepth

### DIFF
--- a/examples/encoder_example.c
+++ b/examples/encoder_example.c
@@ -825,11 +825,11 @@ int main(int argc, char **argv) {
   di.pic_height = avin.video_pic_h;
   switch (avin.video_depth) {
     case 8: {
-      di.bitdepth_mode = OD_BITDEPTH_MODE_8;
+      di.bitdepth_mode = OD_BITDEPTH_8;
       break;
     }
     case 10: {
-      di.bitdepth_mode = OD_BITDEPTH_MODE_10;
+      di.bitdepth_mode = OD_BITDEPTH_10;
       break;
     }
     case 14:
@@ -839,7 +839,7 @@ int main(int argc, char **argv) {
     }
     /* Fall through */
     case 12: {
-      di.bitdepth_mode = OD_BITDEPTH_MODE_12;
+      di.bitdepth_mode = OD_BITDEPTH_12;
       break;
     }
     default: {

--- a/include/daala/codec.h
+++ b/include/daala/codec.h
@@ -192,12 +192,22 @@ struct daala_plane_info {
 /**\name Bit Depths
  * The three video bit depths currently supported by Daala.*/
 /*@{*/
-/**8-bit mode.*/
-#define OD_BITDEPTH_MODE_8 (1)
-/**10-bit mode.*/
-#define OD_BITDEPTH_MODE_10 (2)
-/**12-bit mode.*/
-#define OD_BITDEPTH_MODE_12 (3)
+enum od_bitdepth {
+    /** Bitdepth not defined. */
+    OD_BITDEPTH_NONE = 0,
+
+    /**8-bit mode.*/
+    OD_BITDEPTH_8    = 1,
+
+    /**10-bit mode.*/
+    OD_BITDEPTH_10   = 2,
+
+    /**12-bit mode.*/
+    OD_BITDEPTH_12   = 3,
+
+    /** Not part of ABI. */
+    OD_BITDEPTH_NB
+};
 /*@}*/
 
 /** Configuration parameters for a codec instance. */
@@ -214,9 +224,7 @@ struct daala_info {
   uint32_t timebase_denominator;
   uint32_t frame_duration;
   int keyframe_granule_shift;
-  /** bitdepth_mode is one of the three OD_BITDEPTH_MODE_X choices allowed
-   * above. */
-  int bitdepth_mode;
+  enum od_bitdepth bitdepth_mode;
   int nplanes;
   daala_plane_info plane_info[OD_NPLANES_MAX];
    /** key frame rate defined how often a key frame is emitted by encoder in

--- a/src/decode.c
+++ b/src/decode.c
@@ -70,7 +70,7 @@ static int od_dec_init(od_dec_ctx *dec, const daala_info *info,
   dec->user_mc_img = NULL;
   dec->user_dering = NULL;
   data_sz = 0;
-  output_bits = 8 + (info->bitdepth_mode - OD_BITDEPTH_MODE_8)*2;
+  output_bits = 8 + (info->bitdepth_mode - OD_BITDEPTH_8) * 2;
   output_bytes = output_bits > 8 ? 2 : 1;
   /*TODO: Check for overflow before allocating.*/
   frame_buf_width = dec->state.frame_width + (OD_BUFFER_PADDING << 1);

--- a/src/info.c
+++ b/src/info.c
@@ -36,7 +36,7 @@ void daala_info_init(daala_info *_info) {
   _info->version_minor = OD_VERSION_MINOR;
   _info->version_sub = OD_VERSION_SUB;
   _info->keyframe_granule_shift = 31;
-  _info->bitdepth_mode = OD_BITDEPTH_MODE_8;
+  _info->bitdepth_mode = OD_BITDEPTH_8;
   /*TODO: Set other defaults.*/
 }
 

--- a/src/infodec.c
+++ b/src/infodec.c
@@ -176,8 +176,8 @@ int daala_decode_header_in(daala_info *info,
       if (tmpi < 0 || tmpi >= 32) return OD_EBADHEADER;
       info->keyframe_granule_shift = tmpi;
       info->bitdepth_mode = oggbyte_read1(&obb);
-      if (info->bitdepth_mode < OD_BITDEPTH_MODE_8
-       || info->bitdepth_mode > OD_BITDEPTH_MODE_12) {
+      if (info->bitdepth_mode == OD_BITDEPTH_NONE
+       || info->bitdepth_mode >= OD_BITDEPTH_NB) {
         return OD_EBADHEADER;
       }
       info->nplanes = oggbyte_read1(&obb);

--- a/src/infoenc.c
+++ b/src/infoenc.c
@@ -54,8 +54,8 @@ int daala_encode_flush_header(daala_enc_ctx *_enc, daala_comment *_dc,
       oggbyte_write4(&_enc->obb, info->frame_duration);
       OD_ASSERT(info->keyframe_granule_shift < 32);
       oggbyte_write1(&_enc->obb, info->keyframe_granule_shift);
-      OD_ASSERT(info->bitdepth_mode >= OD_BITDEPTH_MODE_8
-       && info->bitdepth_mode <= OD_BITDEPTH_MODE_12);
+      OD_ASSERT(info->bitdepth_mode > OD_BITDEPTH_NONE
+       && info->bitdepth_mode < OD_BITDEPTH_NB);
       oggbyte_write1(&_enc->obb, info->bitdepth_mode);
       OD_ASSERT((info->nplanes >= 1) && (info->nplanes <= OD_NPLANES_MAX));
       oggbyte_write1(&_enc->obb, info->nplanes);

--- a/src/state.c
+++ b/src/state.c
@@ -234,8 +234,8 @@ static int od_state_init_impl(od_state *state, const daala_info *info) {
   /*The first plane (the luma plane) must not be subsampled.*/
   if (info->plane_info[0].xdec || info->plane_info[0].ydec) return OD_EINVAL;
   /*The bitdepth is restricted to a few allowed values.*/
-  if (info->bitdepth_mode < OD_BITDEPTH_MODE_8
-   || info->bitdepth_mode > OD_BITDEPTH_MODE_12) {
+  if (info->bitdepth_mode == OD_BITDEPTH_NONE
+   || info->bitdepth_mode >= OD_BITDEPTH_NB) {
     return OD_EINVAL;
   }
   OD_CLEAR(state, 1);


### PR DESCRIPTION
This helps during debugging, simplifies validating values, and drops
the unneed MODE tag.