### PR TITLE
Simplify bitstream and pixel format handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ src_libdaalabase_la_SOURCES = \
 	src/generic_code.c \
 	src/generic_decoder.c \
 	src/info.c \
+	src/infoutils.c \
 	src/intra.c \
 	src/laplace_decoder.c \
 	src/laplace_tables.c \

--- a/examples/encoder_example.c
+++ b/examples/encoder_example.c
@@ -61,6 +61,7 @@ struct av_input{
   int video_cur_img;
   int video_depth;
   int video_swapendian;
+  int daala_pix_fmt_code;
 };
 
 #define SWAP(a, b)  do {a ^= b; b ^= a; a ^= b;} while(0)
@@ -369,6 +370,7 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
      avin->video_chroma_type);
     exit(1);
   }
+  avin->daala_pix_fmt_code = daala_lookup_pix_fmt(avin->video_chroma_type);
   img = &avin->video_img;
   img->nplanes = avin->video_nplanes;
   img->width = avin->video_pic_w;
@@ -855,6 +857,7 @@ int main(int argc, char **argv) {
   di.nplanes = avin.video_nplanes;
   memcpy(di.plane_info, avin.video_plane_info,
    di.nplanes*sizeof(*di.plane_info));
+  di.pix_fmt_code = avin.daala_pix_fmt_code;
   di.keyframe_rate = video_keyframe_rate;
   /*TODO: Other crap.*/
   dd = daala_encode_create(&di);

--- a/include/daala/codec.h
+++ b/include/daala/codec.h
@@ -202,6 +202,7 @@ struct daala_plane_info {
 
 /** Configuration parameters for a codec instance. */
 struct daala_info {
+  unsigned char pix_fmt_code;
   unsigned char version_major;
   unsigned char version_minor;
   unsigned char version_sub;

--- a/include/daala/daalaenc.h
+++ b/include/daala/daalaenc.h
@@ -140,6 +140,14 @@ int daala_encode_packet_out(daala_enc_ctx *enc,
 /**Frees an allocated encoder instance.
  * \param enc A #daala_enc_ctx handle.*/
 void daala_encode_free(daala_enc_ctx *enc);
+/**Sets the info details (bit depth code, x/y dec, planes, etc.) from
+ * a pixel format code
+ * \retval 0 Success
+ * \retval 1 Error, pixel format code is invalid **/
+int daala_set_pix_info(daala_info *info, unsigned char code);
+/**Takes a string and outputs a pixel format code
+ * \retval 255 Error, pixel format is invalid **/
+unsigned char daala_lookup_pix_fmt(const char *name);
 /*@}*/
 
 /** \defgroup encctlcodes Configuration keys for the encoder ctl interface.

--- a/src/infodec.c
+++ b/src/infodec.c
@@ -133,7 +133,6 @@ int daala_decode_header_in(daala_info *info,
     /*Codec info header.*/
     case 0x80:
     {
-      int pli;
       uint32_t tmp;
       int tmpi;
       /*This should be the first packet, and we should not have already read
@@ -175,23 +174,8 @@ int daala_decode_header_in(daala_info *info,
       tmpi = oggbyte_read1(&obb);
       if (tmpi < 0 || tmpi >= 32) return OD_EBADHEADER;
       info->keyframe_granule_shift = tmpi;
-      info->bitdepth_mode = oggbyte_read1(&obb);
-      if (info->bitdepth_mode < OD_BITDEPTH_MODE_8
-       || info->bitdepth_mode > OD_BITDEPTH_MODE_12) {
-        return OD_EBADHEADER;
-      }
-      info->nplanes = oggbyte_read1(&obb);
-      if ((info->nplanes < 1) || (info->nplanes > OD_NPLANES_MAX)) {
-        return OD_EBADHEADER;
-      }
-      for (pli = 0; pli < info->nplanes; pli++) {
-        tmpi = oggbyte_read1(&obb);
-        if (tmpi < 0) return OD_EBADHEADER;
-        info->plane_info[pli].xdec = !!tmpi;
-        tmpi = oggbyte_read1(&obb);
-        if (tmpi < 0) return OD_EBADHEADER;
-        info->plane_info[pli].ydec = !!tmpi;
-      }
+      info->pix_fmt_code = oggbyte_read1(&obb);
+      if (daala_set_pix_info(info, info->pix_fmt_code)) return OD_EBADHEADER;
       return 2;
     }
     case 0x81:

--- a/src/infoenc.c
+++ b/src/infoenc.c
@@ -36,7 +36,6 @@ int daala_encode_flush_header(daala_enc_ctx *_enc, daala_comment *_dc,
   switch (_enc->packet_state) {
     case OD_PACKET_INFO_HDR:
     {
-      int pli;
       oggbyte_reset(&_enc->obb);
       oggbyte_write1(&_enc->obb, 0x80);
       oggbyte_writecopy(&_enc->obb, "daala", 5);
@@ -54,15 +53,7 @@ int daala_encode_flush_header(daala_enc_ctx *_enc, daala_comment *_dc,
       oggbyte_write4(&_enc->obb, info->frame_duration);
       OD_ASSERT(info->keyframe_granule_shift < 32);
       oggbyte_write1(&_enc->obb, info->keyframe_granule_shift);
-      OD_ASSERT(info->bitdepth_mode >= OD_BITDEPTH_MODE_8
-       && info->bitdepth_mode <= OD_BITDEPTH_MODE_12);
-      oggbyte_write1(&_enc->obb, info->bitdepth_mode);
-      OD_ASSERT((info->nplanes >= 1) && (info->nplanes <= OD_NPLANES_MAX));
-      oggbyte_write1(&_enc->obb, info->nplanes);
-      for (pli = 0; pli < info->nplanes; ++pli) {
-        oggbyte_write1(&_enc->obb, info->plane_info[pli].xdec);
-        oggbyte_write1(&_enc->obb, info->plane_info[pli].ydec);
-      }
+      oggbyte_write1(&_enc->obb, info->pix_fmt_code);
       _op->b_o_s = 1;
     }
     break;

--- a/src/infoutils.c
+++ b/src/infoutils.c
@@ -1,0 +1,96 @@
+/*Daala video codec
+Copyright (c) 2006-2010 Daala project contributors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+
+#include <string.h>
+#include "encint.h"
+
+#define DAALA_PIX_FMT_NUM 20
+
+struct daala_pix_fmt {
+  const char *name;
+  int bitdepth;
+  int nplanes;
+  int xdec[4];
+  int ydec[4];
+};
+
+static const struct daala_pix_fmt pix_fmt_list[DAALA_PIX_FMT_NUM] = {
+  { "444",        8, 3, {0, 0, 0},    {0, 0, 0}    },
+  { "444p10",    10, 3, {0, 0, 0},    {0, 0, 0}    },
+  { "444p12",    12, 3, {0, 0, 0},    {0, 0, 0}    },
+  { "444p14",    14, 3, {0, 0, 0},    {0, 0, 0}    },
+  { "444p16",    16, 3, {0, 0, 0},    {0, 0, 0}    },
+  { "444alpha",   8, 4, {0, 0, 0, 0}, {0, 0, 0, 0} },
+  { "422",        8, 3, {0, 1, 0},    {0, 1, 0}    },
+  { "422p10",    10, 3, {0, 1, 0},    {0, 1, 0}    },
+  { "422p12",    12, 3, {0, 1, 0},    {0, 1, 0}    },
+  { "422p14",    14, 3, {0, 1, 0},    {0, 1, 0}    },
+  { "422p16",    16, 3, {0, 1, 0},    {0, 1, 0}    },
+  { "411",        8, 3, {0, 2, 0},    {0, 2, 0}    },
+  { "420",        8, 3, {0, 1, 1},    {0, 1, 1}    },
+  { "420jpeg",    8, 3, {0, 1, 1},    {0, 1, 1}    },
+  { "420mpeg2",   8, 3, {0, 1, 1},    {0, 1, 1}    },
+  { "420paldv",   8, 3, {0, 1, 1},    {0, 1, 1}    },
+  { "420p10",    10, 3, {0, 1, 1},    {0, 1, 1}    },
+  { "420p12",    12, 3, {0, 1, 1},    {0, 1, 1}    },
+  { "420p14",    14, 3, {0, 1, 1},    {0, 1, 1}    },
+  { "420p16",    16, 3, {0, 1, 1},    {0, 1, 1}    },
+};
+
+static int daala_lookup_bitdepth_code(int bitdepth)
+{
+  if (bitdepth == 8)
+    return OD_BITDEPTH_MODE_8;
+  else if (bitdepth == 10)
+    return OD_BITDEPTH_MODE_10;
+  else
+    return OD_BITDEPTH_MODE_12;
+}
+
+/* Set format from a code */
+int daala_set_pix_info(daala_info *info, unsigned char code)
+{
+  int i;
+  if (code < 0 || code > DAALA_PIX_FMT_NUM)
+    return 1;
+  info->bitdepth_mode = daala_lookup_bitdepth_code(pix_fmt_list[code].bitdepth);
+  info->nplanes = pix_fmt_list[code].nplanes;
+  for (i = 0; i < info->nplanes; ++i) {
+    info->plane_info[i].xdec = pix_fmt_list[code].xdec[i];
+    info->plane_info[i].ydec = pix_fmt_list[code].ydec[i];
+  }
+  return 0;
+}
+
+/* Look up name and set info, used by the encoder */
+unsigned char daala_lookup_pix_fmt(const char *name)
+{
+  int i;
+  for (i = 0; i < DAALA_PIX_FMT_NUM; i++) {
+    if (!strncmp(pix_fmt_list[i].name, name, strlen(name))) {
+      return i;
+    }
+  }
+  return 255;
+}


### PR DESCRIPTION
This series of commits modifies and simplifies the bitstream. Since xdec, ydec, bit depth and number of planes is derived from the pixel format (e.g. "yuv420p" -> 8 bits/pixel, xdec = ydec = {0,1,1}, planes = 3) it's much simpler to simply send out a single unsigned integer describing the pixel format code.
Granted, this limits the total amount of pixel formats ever supported to 254 (255 is used as an error return code), however it's unlikely that any encoder can support 254 completely different formats.
An array was used to look up and store all different parameters of a pixel format, with it's order taken from the example_encoder file which looks up the pixel format of a raw y4m file.
This commit reduces the total amount of data that needs to get sent for the header by 7 bytes. While this is unlikely to have a big impact on filesize, even at low bitrates, this will make the job of parsing the bitstream easier.