### PR TITLE
Subsamping begone

### DIFF
--- a/examples/dump_video.c
+++ b/examples/dump_video.c
@@ -124,10 +124,19 @@ static void video_write(void) {
     for (pli = 0; pli < img.nplanes; pli++) {
       int plane_width;
       int plane_height;
-      int xdec;
-      int ydec;
-      xdec = img.planes[pli].xdec;
-      ydec = img.planes[pli].ydec;
+      int xdec = 0;
+      int ydec = 0;
+      if (pli && pli != 4)
+        if (img.pixel_format == OD_PIX_YUV422) {
+          xdec = 1;
+        } else if (img.pixel_format == OD_PIX_YUV411) {
+          xdec = 2;
+        } else if (img.pixel_format == OD_PIX_YUV420) {
+          xdec = 1;
+          ydec = 1;
+        }
+      }
+
       plane_width = (img.width + (1 << xdec) - 1) >> xdec;
       plane_height = (img.height + (1 << ydec) - 1) >> ydec;
       for (i = 0; i < plane_height; i++) {

--- a/examples/dump_video.c
+++ b/examples/dump_video.c
@@ -59,6 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include "getopt.h"
 #include "../src/logging.h"
 #include "../include/daala/daaladec.h"
+#include "../include/daala/codec.h"
 
 const char *optstring = "o:r";
 struct option options [] = {
@@ -360,22 +361,16 @@ int main(int argc, char *argv[]) {
     pic_height = di.pic_height;
     fps_num = di.timebase_numerator;
     fps_denom = di.timebase_denominator*di.frame_duration;
-    if (di.nplanes > 1) {
-      /*calculate pixel_fmt based on the xdec & ydec values from one of the
-        chroma planes.*/
-      if (di.plane_info[1].xdec == 1 && di.plane_info[1].ydec == 1) {
-        pix_fmt = 0;
-      }
-      else if (di.plane_info[1].xdec == 1 && di.plane_info[1].ydec == 0) {
-        pix_fmt = 2;
-      }
-      else if (di.plane_info[1].xdec == 0 && di.plane_info[1].ydec == 0) {
-        pix_fmt = 3;
-      }
-    }
-    else {
+
+    if (di.pixel_format == OD_PIX_YUV420)
+      pix_fmt = 0;
+    else if (di.pixel_format == OD_PIX_YUV422)
+      pix_fmt = 2;
+    else if (di.pixel_format == OD_PIX_YUV444)
+      pix_fmt = 3;
+    else if (di.pixel_format == OD_PIX_YUV400)
       pix_fmt = 4;
-    }
+
     if (pix_fmt >= 5 || pix_fmt == 1) {
       fprintf(stderr, "Unknown pixel format: %i\n", pix_fmt);
       exit(1);

--- a/examples/encoder_example.c
+++ b/examples/encoder_example.c
@@ -328,6 +328,7 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
   img->width = avin->video_pic_w;
   img->height = avin->video_pic_h;
   img->bitdepth = avin->video_depth;
+  img->pixel_format = avin->video_format;
   for (pli = 0; pli < img->nplanes; pli++) {
     od_img_plane *iplane;
     iplane = img->planes + pli;
@@ -413,11 +414,25 @@ int fetch_and_process_video(av_input *avin, ogg_page *page,
         od_img_plane *iplane;
         int bytes;
         size_t plane_sz;
+        int xdec = 0;
+        int ydec = 0;
         iplane = img->planes + pli;
         bytes = img->bitdepth > 8 ? 2 : 1;
-        plane_sz = ((avin->video_pic_w + (1 << iplane->xdec) - 1)
-         >> iplane->xdec)*((avin->video_pic_h + (1 << iplane->ydec)
-         - 1) >> iplane->ydec)*bytes;
+
+        if (pli && pli != 4) {
+          if (img->pixel_format == OD_PIX_YUV422) {
+            xdec = 1;
+          } else if (img->pixel_format == OD_PIX_YUV411) {
+            xdec = 2;
+          } else if (img->pixel_format == OD_PIX_YUV420) {
+            xdec = 1;
+            ydec = 1;
+          }
+        }
+
+        plane_sz = ((avin->video_pic_w + (1 << xdec) - 1)
+         >> xdec)*((avin->video_pic_h + (1 << ydec)
+         - 1) >> ydec)*bytes;
         ret = fread(iplane->data, 1, plane_sz, avin->video_infile);
         if (ret != plane_sz) {
           fprintf(stderr, "Error reading YUV frame data.\n");

--- a/examples/encoder_example.c
+++ b/examples/encoder_example.c
@@ -373,6 +373,7 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
   img->nplanes = avin->video_nplanes;
   img->width = avin->video_pic_w;
   img->height = avin->video_pic_h;
+  img->bitdepth = avin->video_depth;
   for (pli = 0; pli < img->nplanes; pli++) {
     od_img_plane *iplane;
     iplane = img->planes + pli;
@@ -385,7 +386,6 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
     iplane->xstride = avin->video_depth > 8 ? 2 : 1;
     iplane->ystride = ((avin->video_pic_w
      + (1<<iplane->xdec)-1)>>iplane->xdec)*iplane->xstride;
-    iplane->bitdepth = avin->video_depth;
     iplane->data = _ogg_malloc(iplane->ystride*
      ((avin->video_pic_h + (1<<iplane->ydec) - 1)>>iplane->ydec));
   }
@@ -462,7 +462,7 @@ int fetch_and_process_video(av_input *avin, ogg_page *page,
         int bytes;
         size_t plane_sz;
         iplane = img->planes + pli;
-        bytes = iplane->bitdepth > 8 ? 2 : 1;
+        bytes = img->bitdepth > 8 ? 2 : 1;
         plane_sz = ((avin->video_pic_w + (1 << iplane->xdec) - 1)
          >> iplane->xdec)*((avin->video_pic_h + (1 << iplane->ydec)
          - 1) >> iplane->ydec)*bytes;

--- a/examples/encoder_example.c
+++ b/examples/encoder_example.c
@@ -56,7 +56,7 @@ struct av_input{
   int video_interlacing;
   char video_chroma_type[16];
   int video_nplanes;
-  daala_plane_info video_plane_info[OD_NPLANES_MAX];
+  int video_format;
   od_img video_img;
   int video_cur_img;
   int video_depth;
@@ -176,6 +176,8 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
   int ret;
   int pli;
   int bi;
+  int xdec[OD_NPLANES_MAX] = { 0 };
+  int ydec[OD_NPLANES_MAX] = { 0 };
   for (bi = 0; bi < 127; bi++) {
     ret = fread(buf + bi, 1, 1, test);
     if (ret < 1) return;
@@ -209,160 +211,112 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
    (double)avin->video_fps_n/avin->video_fps_d, avin->video_chroma_type);
   /*Allocate buffers for the image data.*/
   /*TODO: Specify chroma offsets.*/
-  avin->video_plane_info[0].xdec = 0;
-  avin->video_plane_info[0].ydec = 0;
   avin->video_depth = 8;
-  avin->video_swapendian = 0;
+  avin->video_nplanes = 3;
+  avin->video_swapendian = host_is_big_endian();
   if (strcmp(avin->video_chroma_type, "444") == 0) {
-    avin->video_nplanes = 3;
-    avin->video_plane_info[1].xdec = 0;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 0;
-    avin->video_plane_info[2].ydec = 0;
+    avin->video_format = OD_PIX_YUV444;
   }
   else if (strcmp(avin->video_chroma_type, "444p10") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV444;
     avin->video_depth = 10;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 0;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 0;
-    avin->video_plane_info[2].ydec = 0;
   }
   else if (strcmp(avin->video_chroma_type, "444p12") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV444;
     avin->video_depth = 12;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 0;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 0;
-    avin->video_plane_info[2].ydec = 0;
   }
   else if (strcmp(avin->video_chroma_type, "444p14") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV444;
     avin->video_depth = 14;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 0;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 0;
-    avin->video_plane_info[2].ydec = 0;
   }
   else if (strcmp(avin->video_chroma_type, "444p16") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV444;
     avin->video_depth = 16;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 0;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 0;
-    avin->video_plane_info[2].ydec = 0;
   }
   else if (strcmp(avin->video_chroma_type, "444alpha") == 0) {
     avin->video_nplanes = 4;
-    avin->video_plane_info[1].xdec = 0;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 0;
-    avin->video_plane_info[2].ydec = 0;
-    avin->video_plane_info[3].xdec = 0;
-    avin->video_plane_info[3].ydec = 0;
+    avin->video_format = OD_PIX_YUV444;
   }
   else if (strcmp(avin->video_chroma_type, "422") == 0) {
-    avin->video_nplanes = 3;
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 0;
+    avin->video_format = OD_PIX_YUV422;
+    xdec[1] = 1;
+    xdec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "422p10") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV422;
     avin->video_depth = 10;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 0;
+    xdec[1] = 1;
+    xdec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "422p12") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV422;
     avin->video_depth = 12;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 0;
+    xdec[1] = 1;
+    xdec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "422p14") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV422;
     avin->video_depth = 14;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 0;
+    xdec[1] = 1;
+    xdec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "422p16") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV422;
     avin->video_depth = 16;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 0;
+    xdec[1] = 1;
+    xdec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "411") == 0) {
-    avin->video_nplanes = 3;
-    avin->video_plane_info[1].xdec = 2;
-    avin->video_plane_info[1].ydec = 0;
-    avin->video_plane_info[2].xdec = 2;
-    avin->video_plane_info[2].ydec = 0;
+    avin->video_format = OD_PIX_YUV411;
+    xdec[1] = 2;
+    xdec[2] = 2;
   }
   else if (strcmp(avin->video_chroma_type, "420") == 0 ||
    strcmp(avin->video_chroma_type, "420jpeg") == 0 ||
    strcmp(avin->video_chroma_type, "420mpeg2") == 0 ||
    strcmp(avin->video_chroma_type, "420paldv") == 0) {
-    avin->video_nplanes = 3;
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 1;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 1;
+    avin->video_format = OD_PIX_YUV420;
+    xdec[1] = 1;
+    ydec[1] = 1;
+    xdec[2] = 1;
+    ydec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "420p10") == 0){
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV420;
     avin->video_depth = 10;
     avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 1;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 1;
+    xdec[1] = 1;
+    ydec[1] = 1;
+    xdec[2] = 1;
+    ydec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "420p12") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV420;
     avin->video_depth = 12;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 1;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 1;
+    xdec[1] = 1;
+    ydec[1] = 1;
+    xdec[2] = 1;
+    ydec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "420p14") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV420;
     avin->video_depth = 14;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 1;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 1;
+    xdec[1] = 1;
+    ydec[1] = 1;
+    xdec[2] = 1;
+    ydec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "420p16") == 0) {
-    avin->video_nplanes = 3;
+    avin->video_format = OD_PIX_YUV420;
     avin->video_depth = 16;
-    avin->video_swapendian = host_is_big_endian();
-    avin->video_plane_info[1].xdec = 1;
-    avin->video_plane_info[1].ydec = 1;
-    avin->video_plane_info[2].xdec = 1;
-    avin->video_plane_info[2].ydec = 1;
+    xdec[1] = 1;
+    ydec[1] = 1;
+    xdec[2] = 1;
+    ydec[2] = 1;
   }
   else if (strcmp(avin->video_chroma_type, "mono") == 0) {
     avin->video_nplanes = 1;
+    avin->video_format = OD_PIX_YUV400;
   }
   else {
     fprintf(stderr, "Unknown chroma sampling type: '%s'.\n",
@@ -377,17 +331,15 @@ static void id_y4m_file(av_input *avin, const char *file, FILE *test) {
   for (pli = 0; pli < img->nplanes; pli++) {
     od_img_plane *iplane;
     iplane = img->planes + pli;
-    iplane->xdec = avin->video_plane_info[pli].xdec;
-    iplane->ydec = avin->video_plane_info[pli].ydec;
     /*At this moment, Y4M input is always planar.*/
     /*The input depth need not match the encoded depth.
       The input copy will convert to whatever was set for
        di.bitdepth_mode.*/
     iplane->xstride = avin->video_depth > 8 ? 2 : 1;
     iplane->ystride = ((avin->video_pic_w
-     + (1<<iplane->xdec)-1)>>iplane->xdec)*iplane->xstride;
+     + (1 << xdec[pli]) - 1) >> xdec[pli]) * iplane->xstride;
     iplane->data = _ogg_malloc(iplane->ystride*
-     ((avin->video_pic_h + (1<<iplane->ydec) - 1)>>iplane->ydec));
+     ((avin->video_pic_h + (1 << ydec[pli]) - 1) >> ydec[pli]));
   }
 }
 
@@ -853,8 +805,7 @@ int main(int argc, char **argv) {
   di.pixel_aspect_numerator = avin.video_par_n;
   di.pixel_aspect_denominator = avin.video_par_d;
   di.nplanes = avin.video_nplanes;
-  memcpy(di.plane_info, avin.video_plane_info,
-   di.nplanes*sizeof(*di.plane_info));
+  di.pixel_format = avin.video_format;
   di.keyframe_rate = video_keyframe_rate;
   /*TODO: Other crap.*/
   dd = daala_encode_create(&di);

--- a/examples/player_example.c
+++ b/examples/player_example.c
@@ -595,15 +595,20 @@ void img_to_rgb(player_example *player, SDL_Texture *texture,
   int cr_stride;
   int width;
   int height;
-  int xdec;
-  int ydec;
+  int xdec = 0;
+  int ydec = 0;
   int i;
   int j;
   unsigned char *pixels;
   int pitch;
   /*Assume both C planes are decimated.*/
-  xdec = img->planes[1].xdec;
-  ydec = img->planes[1].ydec;
+  if (img->pixel_format == OD_PIX_YUV422) {
+    xdec = 1;
+  } else if (img->pixel_format == OD_PIX_YUV420) {
+    xdec = 1;
+    ydec = 1;
+  }
+
   y_stride = img->planes[0].ystride;
   cb_stride = img->planes[1].ystride;
   cr_stride = img->planes[2].ystride;

--- a/include/daala/codec.h
+++ b/include/daala/codec.h
@@ -121,6 +121,23 @@ extern "C" {
 # define OD_CS_NSPACES (5)
 /*@}*/
 
+/**\name Pixel formats
+ * Describes how pixels are stored in memory. */
+/*@{*/
+/**Y plane followed by U and V planes*/
+# define OD_PIX_YUV444 (1)
+/**Y plane followed 1x1 subsampled U and V planes.*/
+# define OD_PIX_YUV422 (2)
+/**Y plane followed by 2x1 subsampled U and V planes.*/
+# define OD_PIX_YUV411 (3)
+/**Y plane followed by 2x2 subsampled U and V planes.*/
+# define OD_PIX_YUV420 (4)
+/**Y plane only.*/
+# define OD_PIX_YUV400 (5)
+/**Not part of ABI.*/
+# define OD_PIX_NB (6)
+/*@}*/
+
 /**The maximum number of color planes allowed in a single frame.*/
 # define OD_NPLANES_MAX (4)
 
@@ -169,7 +186,7 @@ struct od_img_plane {
 struct od_img {
   /** Typical 3 planes for Y, Cb, and  Cr. Can have a 4th plane for alpha */
   od_img_plane planes[OD_NPLANES_MAX];
-  /** Number of planes (1 for greyscale, 3 for YCbCr, 4 for YCbCr+Alpha ) */
+  /** Number of planes (1 for greyscale, 3 for YUV, 4 for YUV + Alpha) */
   int nplanes;
   /** Width and height in pixels */
   int32_t width;
@@ -185,8 +202,8 @@ struct od_img {
 /** Subsampling factors for a plane as a power of 2.
  *  4:2:0 would have {0, 0} for Y and {1, 1} for Cb and Cr. */
 struct daala_plane_info {
-  unsigned char xdec;
-  unsigned char ydec;
+  unsigned char xdec[OD_NPLANES_MAX];
+  unsigned char ydec[OD_NPLANES_MAX];
 };
 
 /**\name Bit Depths
@@ -220,7 +237,8 @@ struct daala_info {
    * above. */
   int bitdepth_mode;
   int nplanes;
-  daala_plane_info plane_info[OD_NPLANES_MAX];
+  /** pixel_format is one of the three OD_PIX_X choices allowed above. */
+  int pixel_format;
    /** key frame rate defined how often a key frame is emitted by encoder in
     * number of frames. So 10 means every 10th frame is a keyframe.  */
   int keyframe_rate;

--- a/include/daala/codec.h
+++ b/include/daala/codec.h
@@ -163,12 +163,6 @@ struct od_img_plane {
   /** Distance in memory between two pixels vertically next to each other.
       As with xstride, this value is always in bytes. */
   int ystride;
-  /** 8 for 'normal' video precision; data is unsigned bytes centered on 128.
-      Greater-than-8 indicates high-depth video; data is unnormalized
-      host-endian order unsigned signed 16-bit shorts (two octets).
-      For example, 10 bit video would declare a bit depth of 10, use the
-      lower 10 bits of each 16 bit short, and center on 512. */
-  int bitdepth;
 };
 
 /** Representation of an image or video frame. */
@@ -180,6 +174,12 @@ struct od_img {
   /** Width and height in pixels */
   int32_t width;
   int32_t height;
+  /** 8 for 'normal' video precision; data is unsigned bytes centered on 128.
+      Greater-than-8 indicates high-depth video; data is unnormalized
+      host-endian order unsigned signed 16-bit shorts (two octets).
+      For example, 10 bit video would declare a bit depth of 10, use the
+      lower 10 bits of each 16 bit short, and center on 512. */
+  int bitdepth;
 };
 
 /** Subsampling factors for a plane as a power of 2.

--- a/include/daala/codec.h
+++ b/include/daala/codec.h
@@ -164,12 +164,6 @@ struct od_img_plane {
   /** Image data is stored as an unsigned octet type whether it's
       actually 8 bit or a multi-byte depth. */
   unsigned char *data;
-  /** The decimation factor in the x and y direction. Pixels are reduced
-      by a factor of 2^xdec so 0 is none, 1 is decimated by a factor of 2.
-      ( YUV420 will  have xdec of 1 and ydec also of 1. YUV444 will have
-      xdec and ydec set to zero ). */
-  unsigned char xdec;
-  unsigned char ydec;
   /** Distance in memory between two pixels horizontally next to each other.
       The value is in bytes regardless of the 'actual' underlying depth
       (either unsigned bytes for 8 bit video or unsigned 16 bit shorts for
@@ -197,6 +191,8 @@ struct od_img {
       For example, 10 bit video would declare a bit depth of 10, use the
       lower 10 bits of each 16 bit short, and center on 512. */
   int bitdepth;
+  /** pixel_format is one of the OD_PIX_X choices allowed above. */
+  int pixel_format;
 };
 
 /** Subsampling factors for a plane as a power of 2.
@@ -237,7 +233,7 @@ struct daala_info {
    * above. */
   int bitdepth_mode;
   int nplanes;
-  /** pixel_format is one of the three OD_PIX_X choices allowed above. */
+  /** pixel_format is one of the OD_PIX_X choices allowed above. */
   int pixel_format;
    /** key frame rate defined how often a key frame is emitted by encoder in
     * number of frames. So 10 means every 10th frame is a keyframe.  */

--- a/src/decode.c
+++ b/src/decode.c
@@ -89,13 +89,13 @@ static int od_dec_init(od_dec_ctx *dec, const daala_info *info,
   img->nplanes = info->nplanes;
   img->width = dec->state.frame_width;
   img->height = dec->state.frame_height;
+  img->bitdepth = output_bits;
   for (pli = 0; pli < img->nplanes; pli++) {
     plane_buf_width = frame_buf_width >> info->plane_info[pli].xdec;
     plane_buf_height = frame_buf_height >> info->plane_info[pli].ydec;
     iplane = img->planes + pli;
     iplane->xdec = info->plane_info[pli].xdec;
     iplane->ydec = info->plane_info[pli].ydec;
-    iplane->bitdepth = output_bits;
     /*At this moment, our output is always planar.*/
     iplane->xstride = output_bytes;
     iplane->ystride = plane_buf_width*iplane->xstride;

--- a/src/decode.c
+++ b/src/decode.c
@@ -93,21 +93,17 @@ static int od_dec_init(od_dec_ctx *dec, const daala_info *info,
   img->height = dec->state.frame_height;
   img->bitdepth = output_bits;
   for (pli = 0; pli < img->nplanes; pli++) {
-    plane_buf_width = frame_buf_width >>
-        od_plane_info_tab[info->pixel_format].xdec[pli];
-    plane_buf_height = frame_buf_height >>
-        od_plane_info_tab[info->pixel_format].ydec[pli];
+    int xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
+    int ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
+    plane_buf_width = frame_buf_width >> xdec;
+    plane_buf_height = frame_buf_height >> ydec;
     iplane = img->planes + pli;
-    iplane->xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
-    iplane->ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
     /*At this moment, our output is always planar.*/
     iplane->xstride = output_bytes;
     iplane->ystride = plane_buf_width*iplane->xstride;
     iplane->data = output_img_data
-      + iplane->xstride*(OD_BUFFER_PADDING >>
-                         od_plane_info_tab[info->pixel_format].xdec[pli])
-      + iplane->ystride*(OD_BUFFER_PADDING >>
-                         od_plane_info_tab[info->pixel_format].ydec[pli]);
+      + iplane->xstride*(OD_BUFFER_PADDING >> xdec)
+      + iplane->ystride*(OD_BUFFER_PADDING >> ydec);
     output_img_data += plane_buf_height*iplane->ystride;
   }
 #if OD_ACCOUNTING
@@ -224,11 +220,13 @@ static void od_dec_blank_img(od_img *img) {
   for (pli = 0; pli < img->nplanes; pli++) {
     int plane_buf_size;
     int plane_buf_offset;
+    int xdec = od_plane_info_tab[img->pixel_format].xdec[pli];
+    int ydec = od_plane_info_tab[img->pixel_format].ydec[pli];
     plane_buf_size =
-     (frame_buf_height >> img->planes[pli].ydec) * img->planes[pli].ystride;
+     (frame_buf_height >> ydec) * img->planes[pli].ystride;
     plane_buf_offset =
-      (OD_BUFFER_PADDING >> img->planes[pli].ydec) * img->planes[pli].ystride
-      + (OD_BUFFER_PADDING >> img->planes[pli].xdec);
+      (OD_BUFFER_PADDING >> ydec) * img->planes[pli].ystride
+      + (OD_BUFFER_PADDING >> xdec);
     memset(img->planes[pli].data - plane_buf_offset, 128, plane_buf_size);
   }
 }
@@ -310,7 +308,7 @@ static void od_decode_compute_pred(daala_dec_ctx *dec, od_mb_dec_ctx *ctx,
   int x;
   OD_ASSERT(bs >= 0 && bs < OD_NBSIZES);
   n = 1 << bs + OD_LOG_BSIZE0;
-  xdec = dec->output_img.planes[pli].xdec;
+  xdec = od_plane_info_tab[dec->output_img.pixel_format].xdec[pli];
   w = dec->state.frame_width >> xdec;
   bo = (by << OD_LOG_BSIZE0)*w + (bx << OD_LOG_BSIZE0);
   /*We never use tf on the chroma planes, but if we do it will blow up, which
@@ -535,7 +533,7 @@ static void od_block_decode(daala_dec_ctx *dec, od_mb_dec_ctx *ctx, int bs,
   qm = ctx->qm == OD_HVS_QM ? OD_QM8_Q4_HVS : OD_QM8_Q4_FLAT;
   bx <<= bs;
   by <<= bs;
-  xdec = dec->output_img.planes[pli].xdec;
+  xdec = od_plane_info_tab[dec->output_img.pixel_format].xdec[pli];
   frame_width = dec->state.frame_width;
   w = frame_width >> xdec;
   bo = (by << 2)*w + (bx << 2);
@@ -969,8 +967,8 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
   /*Apply the prefilter to the motion-compensated reference.*/
   if (!mbctx->is_keyframe) {
     for (pli = 0; pli < nplanes; pli++) {
-      xdec = rec->planes[pli].xdec;
-      ydec = rec->planes[pli].ydec;
+      xdec = od_plane_info_tab[rec->pixel_format].xdec[pli];
+      ydec = od_plane_info_tab[rec->pixel_format].ydec[pli];
       w = frame_width >> xdec;
       h = frame_height >> ydec;
       /*Collect the image data needed for this plane.*/
@@ -1011,8 +1009,8 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
         mbctx->mc = state->mctmp[pli];
         mbctx->md = state->mdtmp[pli];
         mbctx->l = state->lbuf[pli];
-        xdec = dec->output_img.planes[pli].xdec;
-        ydec = dec->output_img.planes[pli].ydec;
+        xdec = od_plane_info_tab[dec->output_img.pixel_format].xdec[pli];
+        ydec = od_plane_info_tab[dec->output_img.pixel_format].ydec[pli];
         if (mbctx->is_keyframe) {
           od_decode_haar_dc_sb(dec, mbctx, pli, sbx, sby, xdec, ydec,
            sby > 0 && sbx < nhsb - 1, &hgrad, &vgrad);
@@ -1023,8 +1021,8 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
     }
   }
   for (pli = 0; pli < nplanes; pli++) {
-    xdec = dec->output_img.planes[pli].xdec;
-    ydec = dec->output_img.planes[pli].ydec;
+    xdec = od_plane_info_tab[dec->output_img.pixel_format].xdec[pli];
+    ydec = od_plane_info_tab[dec->output_img.pixel_format].ydec[pli];
     w = frame_width >> xdec;
     h = frame_height >> ydec;
     if (!mbctx->use_haar_wavelet) {
@@ -1037,8 +1035,8 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
     for (pli = 0; pli < nplanes; pli++) {
       int i;
       int size;
-      xdec = dec->output_img.planes[pli].xdec;
-      ydec = dec->output_img.planes[pli].ydec;
+      xdec = od_plane_info_tab[dec->output_img.pixel_format].xdec[pli];
+      ydec = od_plane_info_tab[dec->output_img.pixel_format].ydec[pli];
       size = nvsb*nhsb*OD_BSIZE_MAX*OD_BSIZE_MAX >> xdec >> ydec;
       for (i = 0; i < size; i++) {
         state->etmp[pli][i] = state->ctmp[pli][i];
@@ -1073,8 +1071,8 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
             int ln;
             int n;
             int dir[OD_DERING_NBLOCKS][OD_DERING_NBLOCKS];
-            xdec = dec->output_img.planes[pli].xdec;
-            ydec = dec->output_img.planes[pli].ydec;
+            xdec = od_plane_info_tab[dec->output_img.pixel_format].xdec[pli];
+            ydec = od_plane_info_tab[dec->output_img.pixel_format].ydec[pli];
             w = frame_width >> xdec;
             h = frame_height >> ydec;
             ln = OD_LOG_BSIZE_MAX - xdec;
@@ -1115,8 +1113,8 @@ static void od_decode_coefficients(od_dec_ctx *dec, od_mb_dec_ctx *mbctx) {
     }
   }
   for (pli = 0; pli < nplanes; pli++) {
-    xdec = dec->output_img.planes[pli].xdec;
-    ydec = dec->output_img.planes[pli].ydec;
+    xdec = od_plane_info_tab[dec->output_img.pixel_format].xdec[pli];
+    ydec = od_plane_info_tab[dec->output_img.pixel_format].ydec[pli];
     w = frame_width >> xdec;
     h = frame_height >> ydec;
     if (dec->quantizer[0] > 0)

--- a/src/decode.c
+++ b/src/decode.c
@@ -76,8 +76,10 @@ static int od_dec_init(od_dec_ctx *dec, const daala_info *info,
   frame_buf_width = dec->state.frame_width + (OD_BUFFER_PADDING << 1);
   frame_buf_height = dec->state.frame_height + (OD_BUFFER_PADDING << 1);
   for (pli = 0; pli < info->nplanes; pli++) {
-    plane_buf_width = frame_buf_width >> info->plane_info[pli].xdec;
-    plane_buf_height = frame_buf_height >> info->plane_info[pli].ydec;
+    plane_buf_width = frame_buf_width >>
+        od_plane_info_tab[info->pixel_format].xdec[pli];
+    plane_buf_height = frame_buf_height >>
+        od_plane_info_tab[info->pixel_format].ydec[pli];
     data_sz += plane_buf_width*plane_buf_height*output_bytes;
   }
   dec->output_img_data = output_img_data =
@@ -91,17 +93,21 @@ static int od_dec_init(od_dec_ctx *dec, const daala_info *info,
   img->height = dec->state.frame_height;
   img->bitdepth = output_bits;
   for (pli = 0; pli < img->nplanes; pli++) {
-    plane_buf_width = frame_buf_width >> info->plane_info[pli].xdec;
-    plane_buf_height = frame_buf_height >> info->plane_info[pli].ydec;
+    plane_buf_width = frame_buf_width >>
+        od_plane_info_tab[info->pixel_format].xdec[pli];
+    plane_buf_height = frame_buf_height >>
+        od_plane_info_tab[info->pixel_format].ydec[pli];
     iplane = img->planes + pli;
-    iplane->xdec = info->plane_info[pli].xdec;
-    iplane->ydec = info->plane_info[pli].ydec;
+    iplane->xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
+    iplane->ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
     /*At this moment, our output is always planar.*/
     iplane->xstride = output_bytes;
     iplane->ystride = plane_buf_width*iplane->xstride;
     iplane->data = output_img_data
-      + iplane->xstride*(OD_BUFFER_PADDING >> info->plane_info[pli].xdec)
-      + iplane->ystride*(OD_BUFFER_PADDING >> info->plane_info[pli].ydec);
+      + iplane->xstride*(OD_BUFFER_PADDING >>
+                         od_plane_info_tab[info->pixel_format].xdec[pli])
+      + iplane->ystride*(OD_BUFFER_PADDING >>
+                         od_plane_info_tab[info->pixel_format].ydec[pli]);
     output_img_data += plane_buf_height*iplane->ystride;
   }
 #if OD_ACCOUNTING

--- a/src/encode.c
+++ b/src/encode.c
@@ -262,22 +262,23 @@ static int od_enc_init(od_enc_ctx *enc, const daala_info *info) {
   /*Fill in the input img structure.*/
   img = &enc->input_img;
   img->nplanes = info->nplanes;
+  img->pixel_format = info->pixel_format;
   img->width = enc->state.frame_width;
   img->height = enc->state.frame_height;
   img->bitdepth = reference_bits;
   for (pli = 0; pli < img->nplanes; pli++) {
-    iplane->xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
-    iplane->ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
+    int xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
+    int ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
     iplane = img->planes + pli;
-    plane_buf_width = frame_buf_width >> iplane->xdec;
-    plane_buf_height = frame_buf_height >> iplane->ydec;
+    plane_buf_width = frame_buf_width >> xdec;
+    plane_buf_height = frame_buf_height >> ydec;
 
     /*Internal buffers are always planar.*/
     iplane->xstride = reference_bytes;
     iplane->ystride = plane_buf_width*iplane->xstride;
     iplane->data = input_img_data
-     + iplane->xstride*(OD_BUFFER_PADDING >> iplane->xdec)
-     + iplane->ystride*(OD_BUFFER_PADDING >> iplane->ydec);
+     + iplane->xstride*(OD_BUFFER_PADDING >> xdec)
+     + iplane->ystride*(OD_BUFFER_PADDING >> ydec);
     input_img_data += plane_buf_height*iplane->ystride;
   }
 #if defined(OD_DUMP_IMAGES)
@@ -292,14 +293,15 @@ static int od_enc_init(od_enc_ctx *enc, const daala_info *info) {
   /*Fill in the visualization image structure.*/
   img = &enc->vis_img;
   img->nplanes = info->nplanes;
+  img->pixel_format = info->pixel_format;
   img->width = frame_buf_width << 1;
   img->height = frame_buf_height << 1;
   for (pli = 0; pli < img->nplanes; pli++) {
-    iplane->xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
-    iplane->ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
+    int xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
+    int ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
     iplane = img->planes + pli;
-    plane_buf_width = img->width >> iplane->xdec;
-    plane_buf_height = img->height >> iplane->ydec;
+    plane_buf_width = img->width >> xdec;
+    plane_buf_height = img->height >> ydec;
     iplane->data = input_img_data;
     input_img_data += plane_buf_width*plane_buf_height;
 
@@ -310,14 +312,15 @@ static int od_enc_init(od_enc_ctx *enc, const daala_info *info) {
   /*Fill in the temporary image structure.*/
   img = &enc->tmp_vis_img;
   img->nplanes = info->nplanes;
+  img->pixel_format = info->pixel_format;
   img->width = frame_buf_width << 1;
   img->height = frame_buf_height << 1;
   for (pli = 0; pli < img->nplanes; pli++) {
-    iplane->xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
-    iplane->ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
+    int xdec = od_plane_info_tab[info->pixel_format].xdec[pli];
+    int ydec = od_plane_info_tab[info->pixel_format].ydec[pli];
     iplane = img->planes + pli;
-    plane_buf_width = img->width >> iplane->xdec;
-    plane_buf_height = img->height >> iplane->ydec;
+    plane_buf_width = img->width >> xdec;
+    plane_buf_height = img->height >> ydec;
     iplane->data = input_img_data;
     input_img_data += plane_buf_width*plane_buf_height;
     iplane->bitdepth = 8;
@@ -628,7 +631,7 @@ static void od_encode_compute_pred(daala_enc_ctx *enc, od_mb_enc_ctx *ctx,
   int x;
   OD_ASSERT(bs >= 0 && bs < OD_NBSIZES);
   n = 1 << bs + OD_LOG_BSIZE0;
-  xdec = enc->input_img.planes[pli].xdec;
+  xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
   w = enc->state.frame_width >> xdec;
   bo = (by << OD_LOG_BSIZE0)*w + (bx << OD_LOG_BSIZE0);
   /*We never use tf on the chroma planes, but if we do it will blow up, which
@@ -1002,7 +1005,7 @@ static int od_block_encode(daala_enc_ctx *enc, od_mb_enc_ctx *ctx, int bs,
   n = 1 << (bs + 2);
   bx <<= bs;
   by <<= bs;
-  xdec = enc->input_img.planes[pli].xdec;
+  xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
   frame_width = enc->state.frame_width;
   use_masking = enc->use_activity_masking;
   w = frame_width >> xdec;
@@ -1623,11 +1626,9 @@ static void od_img_copy_pad(daala_enc_ctx *enc, od_img *img) {
     od_img_plane plane;
     int plane_width;
     int plane_height;
-    int xdec;
-    int ydec;
+    int xdec = od_plane_info_tab[img->pixel_format].xdec[pli];
+    int ydec = od_plane_info_tab[img->pixel_format].ydec[pli];
     *&plane = *(img->planes + pli);
-    xdec = plane.xdec;
-    ydec = plane.ydec;
     plane_width = ((state->info.pic_width + (1 << xdec) - 1) >> xdec);
     plane_height = ((state->info.pic_height + (1 << ydec) - 1) >> ydec);
     od_img_plane_copy_pad8(enc->input_img.planes+pli,
@@ -2264,8 +2265,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
     od_ec_enc_uint(&enc->ec, enc->coded_quantizer[pli], OD_N_CODED_QUANTIZERS);
   }
   for (pli = 0; pli < nplanes; pli++) {
-    xdec = enc->input_img.planes[pli].xdec;
-    ydec = enc->input_img.planes[pli].ydec;
+    xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
+    ydec = od_plane_info_tab[enc->input_img.pixel_format].ydec[pli];
     w = frame_width >> xdec;
     h = frame_height >> ydec;
     /*Collect the image data needed for this plane.*/
@@ -2316,8 +2317,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
         mbctx->mc = state->mctmp[pli];
         mbctx->md = state->mdtmp[pli];
         mbctx->l = state->lbuf[pli];
-        xdec = enc->input_img.planes[pli].xdec;
-        ydec = enc->input_img.planes[pli].ydec;
+        xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
+        ydec = od_plane_info_tab[enc->input_img.pixel_format].ydec[pli];
         if (pli == 0 || rdo_only && mbctx->is_keyframe) {
           for (i = 0; i < OD_BSIZE_MAX; i++) {
             for (j = 0; j < OD_BSIZE_MAX; j++) {
@@ -2383,8 +2384,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
   }
 #endif
   for (pli = 0; pli < nplanes; pli++) {
-    xdec = enc->input_img.planes[pli].xdec;
-    ydec = enc->input_img.planes[pli].ydec;
+    xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
+    ydec = od_plane_info_tab[enc->input_img.pixel_format].ydec[pli];
     w = frame_width >> xdec;
     h = frame_height >> ydec;
     if (!mbctx->use_haar_wavelet) {
@@ -2399,8 +2400,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
     for (pli = 0; pli < nplanes; pli++) {
       int i;
       int size;
-      xdec = enc->input_img.planes[pli].xdec;
-      ydec = enc->input_img.planes[pli].ydec;
+      xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
+      ydec = od_plane_info_tab[enc->input_img.pixel_format].ydec[pli];
       size = nvsb*nhsb*OD_BSIZE_MAX*OD_BSIZE_MAX >> xdec >> ydec;
       for (i = 0; i < size; i++) {
         state->etmp[pli][i] = state->ctmp[pli][i];
@@ -2429,8 +2430,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
           continue;
         }
         pli = 0;
-        xdec = enc->input_img.planes[pli].xdec;
-        ydec = enc->input_img.planes[pli].ydec;
+        xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
+        ydec = od_plane_info_tab[enc->input_img.pixel_format].ydec[pli];
         w = frame_width >> xdec;
         OD_ASSERT(xdec == ydec);
         ln = OD_LOG_BSIZE_MAX - xdec;
@@ -2506,8 +2507,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
             }
           }
           for (pli = 1; pli < nplanes; pli++) {
-            xdec = enc->input_img.planes[pli].xdec;
-            ydec = enc->input_img.planes[pli].ydec;
+            xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
+            ydec = od_plane_info_tab[enc->input_img.pixel_format].ydec[pli];
             w = frame_width >> xdec;
             ln = OD_LOG_BSIZE_MAX - xdec;
             n = 1 << ln;
@@ -2529,8 +2530,8 @@ static void od_encode_coefficients(daala_enc_ctx *enc, od_mb_enc_ctx *mbctx,
     }
   }
   for (pli = 0; pli < nplanes; pli++) {
-    xdec = enc->input_img.planes[pli].xdec;
-    ydec = enc->input_img.planes[pli].ydec;
+    xdec = od_plane_info_tab[enc->input_img.pixel_format].xdec[pli];
+    ydec = od_plane_info_tab[enc->input_img.pixel_format].ydec[pli];
     w = frame_width >> xdec;
     h = frame_height >> ydec;
     if (!rdo_only && enc->quantizer[0] > 0) {
@@ -2691,12 +2692,8 @@ int daala_encode_img_in(daala_enc_ctx *enc, od_img *img, int duration) {
      declared video size.*/
   nplanes = enc->state.info.nplanes;
   if (img->nplanes != nplanes) return OD_EINVAL;
-  for (pli = 0; pli < nplanes; pli++) {
-    if (img->planes[pli].xdec != od_plane_info_tab[enc->state.info.pixel_format].xdec[pli]
-     || img->planes[pli].ydec != od_plane_info_tab[enc->state.info.pixel_format].ydec[pli]) {
-      return OD_EINVAL;
-    }
-  }
+  if (img->pixel_format != enc->state.info.pixel_format) return OD_EINVAL;
+
   use_masking = enc->use_activity_masking;
   frame_width = enc->state.frame_width;
   frame_height = enc->state.frame_height;

--- a/src/infodec.c
+++ b/src/infodec.c
@@ -133,7 +133,6 @@ int daala_decode_header_in(daala_info *info,
     /*Codec info header.*/
     case 0x80:
     {
-      int pli;
       uint32_t tmp;
       int tmpi;
       /*This should be the first packet, and we should not have already read
@@ -184,13 +183,9 @@ int daala_decode_header_in(daala_info *info,
       if ((info->nplanes < 1) || (info->nplanes > OD_NPLANES_MAX)) {
         return OD_EBADHEADER;
       }
-      for (pli = 0; pli < info->nplanes; pli++) {
-        tmpi = oggbyte_read1(&obb);
-        if (tmpi < 0) return OD_EBADHEADER;
-        info->plane_info[pli].xdec = !!tmpi;
-        tmpi = oggbyte_read1(&obb);
-        if (tmpi < 0) return OD_EBADHEADER;
-        info->plane_info[pli].ydec = !!tmpi;
+      info->pixel_format = oggbyte_read1(&obb);
+      if ((info->pixel_format == 0) || (info->pixel_format > OD_NPLANES_MAX)) {
+        return OD_EBADHEADER;
       }
       return 2;
     }

--- a/src/infoenc.c
+++ b/src/infoenc.c
@@ -36,7 +36,6 @@ int daala_encode_flush_header(daala_enc_ctx *_enc, daala_comment *_dc,
   switch (_enc->packet_state) {
     case OD_PACKET_INFO_HDR:
     {
-      int pli;
       oggbyte_reset(&_enc->obb);
       oggbyte_write1(&_enc->obb, 0x80);
       oggbyte_writecopy(&_enc->obb, "daala", 5);
@@ -59,10 +58,7 @@ int daala_encode_flush_header(daala_enc_ctx *_enc, daala_comment *_dc,
       oggbyte_write1(&_enc->obb, info->bitdepth_mode);
       OD_ASSERT((info->nplanes >= 1) && (info->nplanes <= OD_NPLANES_MAX));
       oggbyte_write1(&_enc->obb, info->nplanes);
-      for (pli = 0; pli < info->nplanes; ++pli) {
-        oggbyte_write1(&_enc->obb, info->plane_info[pli].xdec);
-        oggbyte_write1(&_enc->obb, info->plane_info[pli].ydec);
-      }
+      oggbyte_write1(&_enc->obb, info->pixel_format);
       _op->b_o_s = 1;
     }
     break;

--- a/src/internal.c
+++ b/src/internal.c
@@ -388,6 +388,15 @@ uint32_t OD_DIVU_SMALL_CONSTS[OD_DIVU_DMAX][2] = {
   {0xFFFFFFFF,0xFFFFFFFF}
 };
 
+const daala_plane_info od_plane_info_tab[OD_PIX_NB] = {
+  {{ 0, 0, 0 }, { 0, 0, 0 }}, /* n/a */
+  {{ 0, 0, 0 }, { 0, 0, 0 }}, /* OD_PIX_YUV444 */
+  {{ 0, 1, 0 }, { 0, 1, 0 }}, /* OD_PIX_YUV422 */
+  {{ 0, 2, 0 }, { 0, 2, 0 }}, /* OD_PIX_YUV411 */
+  {{ 0, 1, 1 }, { 0, 1, 1 }}, /* OD_PIX_YUV420 */
+  {{ 0, 0, 0 }, { 0, 0, 0 }}, /* OD_PIX_YUV400 */
+};
+
 #if defined(OD_ENABLE_ASSERTIONS)
 # include <stdio.h>
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -205,6 +205,8 @@ void od_free_2d(void *_ptr);
 
 extern uint32_t OD_DIVU_SMALL_CONSTS[OD_DIVU_DMAX][2];
 
+extern const daala_plane_info od_plane_info_tab[OD_PIX_NB];
+
 /*Translate unsigned division by small divisors into multiplications.*/
 # define OD_DIVU_SMALL(_x, _d) \
   ((uint32_t)((OD_DIVU_SMALL_CONSTS[(_d)-1][0]* \

--- a/src/state.c
+++ b/src/state.c
@@ -154,13 +154,13 @@ static int od_state_ref_imgs_init(od_state *state, int nrefs) {
     img->nplanes = info->nplanes;
     img->width = state->frame_width;
     img->height = state->frame_height;
+    img->bitdepth = reference_bits;
     for (pli = 0; pli < img->nplanes; pli++) {
       iplane = img->planes + pli;
       iplane->xdec = info->plane_info[pli].xdec;
       iplane->ydec = info->plane_info[pli].ydec;
       plane_buf_width = frame_buf_width >> iplane->xdec;
       plane_buf_height = frame_buf_height >> iplane->ydec;
-      iplane->bitdepth = reference_bits;
       iplane->xstride = reference_bytes;
       iplane->ystride = plane_buf_width*reference_bytes;
       iplane->data = ref_img_data


### PR DESCRIPTION
this PR aims at simplifying the API so that it is no more necessary to carry over sub-sampling values for each image

 - a set of pixel format values is introduced so that the library and applications can easily derive them when necessary (with a private table and with simple ifs respectively)
 - applications don't have to initialize subsampling themselves, so it's less error prone
 - header is trimmed so that only pixel format, planes and bitdepth are stored
 - there are some simplifications here and there in the library itself

I'd like to make a few modifications to this pr, but I wanted to put it out here so that there can be a proper discussion about it