### PR TITLE
Fix skipping too often in od_pvq_encode

### DIFF
--- a/src/pvq_encoder.c
+++ b/src/pvq_encoder.c
@@ -662,7 +662,7 @@ int od_pvq_encode(daala_enc_ctx *enc,
   int size[PVQ_MAX_PARTITIONS];
   generic_encoder *model;
   double skip_diff;
-  unsigned tell;
+  int tell;
   uint16_t *skip_cdf;
   od_rollback_buffer buf;
   int dc_quant;


### PR DESCRIPTION
The variable tell in od_pvq_encode() can sometimes be calculated
negative but is unsigned.
So it blows out the comparison skip_diff <= OD_PVQ_LAMBDA/8*tell.
Make it signed, as it is in od_pvq_rate().

This fixes #166.