### PR TITLE
Fix log scale in dump_ciede2000.py

### DIFF
--- a/tools/dump_ciede2000.py
+++ b/tools/dump_ciede2000.py
@@ -34,7 +34,7 @@ def process_pair(ref, recons):
     # Yang Yang, Jun Ming and Nenghai Yu, 2012
     # http://dx.doi.org/10.1155/2012/273723
     dE = color.deltaE_ciede2000(ref_lab, recons_lab, kL=0.65, kC=1.0, kH=4.0)
-    scores.append(20. * np.log10(dE.mean()))
+    scores.append(45. - 20. * np.log10(dE.mean()))
     print('%08d: %2.4f' % (ref.count, scores[-1]))
 
 


### PR DESCRIPTION
The initial log scale was ```20*log10(mean(ciede2000))``` which absurdly increases as quality lowers.
So negate the scale and offset ```45-20*log10(mean(ciede2000))``` where ```20*log10(10**2.25)==45``` because the range of delta values for all Rec.709 YCbCr values is bounded by ```10**2.25```, given our parameters. The scale should be similar to PSNR.