### PR TITLE
Apply k=1 tweak for beta=1, ref and noref

### DIFF
--- a/src/pvq.c
+++ b/src/pvq.c
@@ -887,7 +887,7 @@ int od_pvq_compute_k(od_val32 qcg, int itheta, od_val32 theta, int noref, int n,
 #endif
   if (noref) {
     if (qcg == 0) return 0;
-    if (n == 15 && qcg == OD_CGAIN_SCALE && beta > OD_BETA(1.25)) {
+    if (n == 15 && qcg == OD_CGAIN_SCALE) {
       return 1;
     }
     else {
@@ -914,6 +914,7 @@ int od_pvq_compute_k(od_val32 qcg, int itheta, od_val32 theta, int noref, int n,
        approximation for the fact that the coefficients aren't identically
        distributed within a band so at low gain the number of dimensions that
        are likely to have a pulse is less than n. */
+    if (n == 15 && itheta == 1 && beta == OD_BETA(1)) return 1;
     if (nodesync) {
 #if defined(OD_FLOAT_PVQ)
       return OD_MAXI(1, (int)floor(.5 + (itheta - .2)*sqrt((n + 2)/2)));


### PR DESCRIPTION
### subset1
````
           RATE (%) DSNR (dB)
    PSNR -0.132183 0.00574649
 PSNRHVS -0.187846 0.0124809
    SSIM -0.0780694 0.00274665
FASTSSIM -0.232905 0.00647426
```
### objective-1-fast
```
PSNR YCbCr:     -0.06%     -1.16%     -0.88%
   PSNRHVS:     -0.19%
      SSIM:     -0.02%
    MSSSIM:     -0.15%
 CIEDE2000:     -0.41%
```
<details><summary>[AWCY report](https://arewecompressedyet.com/?r%5B%5D=compute_k_1_am-ed28a6a0-2016-09-02T12-28-34.462Z&r%5B%5D=master-2016-08-26-b5607d6&s=objective-1-fast) (expand for per-video results)</summary>
```
                                    file      PSNR   PSNRHVS      SSIM    MSSSIM CIEDE2000   PSNR Cb   PSNR Cr 
------------------------------------------------------------------------------------------
                       DOTA2_60f_420.y4m      0.14     -0.15      0.00     -0.11      0.14      0.79      1.24 
         KristenAndSara_1280x720_60f.y4m      0.28      0.33      0.30      0.22     -0.48     -1.94     -1.92 
                   MINECRAFT_60f_420.y4m     -0.11     -0.46     -0.18     -0.44     -1.05     -2.73     -3.18 
Netflix_Aerial_1920x1080_60fps_8bit_420_      0.08     -0.01     -0.00     -0.05     -0.02     -0.64     -2.19 
Netflix_Boat_1920x1080_60fps_8bit_420_60     -0.06     -0.30     -0.02     -0.23     -0.27     -1.43     -0.85 
Netflix_Crosswalk_1920x1080_60fps_8bit_4     -0.13     -0.13     -0.18     -0.18      0.10     -0.13      0.01 
Netflix_DrivingPOV_1280x720_60fps_8bit_4     -0.27     -0.44     -0.30     -0.38     -1.29     -4.58     -3.33 
Netflix_FoodMarket_1920x1080_60fps_8bit_      0.00     -0.04     -0.02     -0.06     -0.35     -1.36     -0.94 
Netflix_PierSeaside_1920x1080_60fps_8bit     -0.22     -0.44     -0.06     -0.32     -1.05     -2.13     -1.49 
Netflix_RollerCoaster_1280x720_60fps_8bi     -0.12     -0.21     -0.03     -0.08     -0.65     -0.73     -0.99 
Netflix_SquareAndTimelapse_1920x1080_60f     -0.24     -0.52     -0.29     -0.41     -0.64     -1.03     -1.33 
Netflix_TunnelFlag_1920x1080_60fps_8bit_     -0.04     -0.31     -0.11     -0.20     -0.85     -2.24     -1.84 
                   STARCRAFT_60f_420.y4m     -0.28     -0.05      0.21      0.02     -0.18     -1.03      0.07 
                     aspen_1080p_60f.y4m     -0.03     -0.15     -0.09     -0.09      0.38      0.30      0.02 
                   blue_sky_360p_60f.y4m     -0.02     -0.23      0.22     -0.02      1.01      0.94      1.05 
                         dark70p_60f.y4m      0.18     -0.26      0.05     -0.15     -0.16     -0.96     -0.70 
          ducks_take_off_1080p50_60f.y4m     -0.10     -0.19     -0.10     -0.27     -0.35     -1.29     -2.93 
                  gipsrestat720p_60f.y4m      0.31      0.01      0.29      0.16     -0.15     -1.87     -0.31 
                     kirland360p_60f.y4m      1.13      0.31      0.73      0.30      1.28      0.95      1.21 
                    life_1080p30_60f.y4m     -0.08     -0.38      0.02      0.02     -0.21      0.01     -0.60 
                      niklas360p_60f.y4m     -0.11     -0.03      0.06     -0.07     -0.19     -1.00     -2.12 
                  red_kayak_360p_60f.y4m     -0.31     -0.06     -0.18     -0.17     -0.04      0.33      0.87 
               rush_hour_1080p25_60f.y4m      0.11      0.06      0.08      0.04     -0.86     -1.37     -1.17 
                 shields_640x360_60f.y4m     -0.20     -0.50     -0.23     -0.43     -0.05      2.22      0.58 
               speed_bag_640x360_60f.y4m     -0.15     -0.12     -0.07      0.09     -3.16     -4.25     -1.44 
              thaloundeskmtg360p_60f.y4m     -0.39      0.12      0.19     -0.17     -0.37     -2.03     -0.06 
            touchdown_pass_1080p_60f.y4m      0.15     -0.13      0.12     -0.06     -0.34     -4.57     -2.62 
               vidyo1_720p_60fps_60f.y4m      0.37     -0.10      0.08      0.00     -0.11     -1.22     -0.21 
               vidyo4_720p_60fps_60f.y4m      0.29     -0.22      0.02     -0.05     -0.51     -0.90      0.38 
                       wikipedia_420.y4m     -1.83     -1.06     -1.11     -1.31     -1.81     -0.94     -1.52 
------------------------------------------------------------------------------------------
                                 Average     -0.06     -0.19     -0.02     -0.15     -0.41     -1.16     -0.88 
AWCY Report v0.4
Reference: master-2016-08-26-b5607d6
Test Run: compute_k_1_am-ed28a6a0-2016-09-02T12-28-34.462Z
Range: overlap
```
</details>