### PR TITLE
Fully order the pvq search candidates for portable, stable sorting

### DIFF
--- a/src/pvq_encoder.c
+++ b/src/pvq_encoder.c
@@ -283,7 +283,9 @@ typedef struct {
 } pvq_search_item;
 
 int items_compare(pvq_search_item *a, pvq_search_item *b) {
-  return a->k - b->k;
+  /* Break ties in K with gain to ensure a stable sort.
+     Otherwise, the order depends on qsort implementation. */
+  return a->k == b->k ? a->gain - b->gain : a->k - b->k;
 }
 
 /** Perform PVQ quantization with prediction, trying several


### PR DESCRIPTION
I observed different results from AWCY when running the same commit, test clip and configuration on my MacBook.
It occurred to me that it could be a result of differences in qsort implementation.
Adjusting the sort key to produce a stable sort indeed fixed this for me. 

https://arewecompressedyet.com/?r%5B%5D=pvq-sort-good-2016-09-06T02-43-53.523Z&r%5B%5D=master_2016-09-03d&s=objective-1-fast