### PR TITLE
issue #116 - Now the player does not fill the desktop but instead ret…

### DIFF
--- a/examples/player_example.c
+++ b/examples/player_example.c
@@ -282,7 +282,7 @@ void player_example_handle_event(player_example *player, SDL_Event *event) {
         case SDLK_f: {
           player->fullscreen = !player->fullscreen;
           SDL_SetWindowFullscreen(player->screen,
-              player->fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+              player->fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
           img_to_rgb(player, player->texture, &player->img, player->plane_mask);
           player_example_display_frame(player);
           break;


### PR DESCRIPTION
Now the player does not 'fill' the desktop but instead retains its aspect ratio.

As per the SDL documenation: 
[https://wiki.libsdl.org/SDL_SetWindowFullscreen](https://wiki.libsdl.org/SDL_SetWindowFullscreen)

> SDL_WINDOW_FULLSCREEN, for "real" fullscreen with a videomode change; SDL_WINDOW_FULLSCREEN_DESKTOP for "fake" fullscreen that takes the size of the desktop;