### PR TITLE
this fixes issue116 and explicitly maintains the aspect ratio in the …

### DIFF
--- a/examples/player_example.c
+++ b/examples/player_example.c
@@ -280,11 +280,38 @@ void player_example_handle_event(player_example *player, SDL_Event *event) {
           break;
         }
         case SDLK_f: {
+  
+	  // store the original aspect ratio for reference 
+	  int width = event->window.data1;
+  	  int height = event->window.data2;
+  	  const float ASPECT_RATIO = (float)width/(float)height;
+	  float aspectRatio;
+
           player->fullscreen = !player->fullscreen;
-          SDL_SetWindowFullscreen(player->screen,
-              player->fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+	  SDL_SetWindowFullscreen(player->screen,
+              player->fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
           img_to_rgb(player, player->texture, &player->img, player->plane_mask);
-          player_example_display_frame(player);
+          
+	  // calculate the aspectRatio after the player->screen has been modified
+	  width = player->width;
+	  height = player->height;
+  	  aspectRatio = (float)width/(float)height;
+          
+	  // compare and rectify, to maintain the original aspect ratio
+	  if(aspectRatio != ASPECT_RATIO) {
+            if(aspectRatio > ASPECT_RATIO) {
+              height = (1.f / ASPECT_RATIO) * width; 
+            }
+            else {
+              width = ASPECT_RATIO * height; 
+            }
+            printf("Setting window size to %d, %d, aspect ratio: %f\n", 
+                    width, height, (float)width/(float)height);
+          }
+          player->width = width;
+          player->height = height;
+	  
+	  player_example_display_frame(player);
           break;
         }
         default: break;
@@ -294,7 +321,7 @@ void player_example_handle_event(player_example *player, SDL_Event *event) {
     case SDL_WINDOWEVENT: {
       switch (event->window.event) {
         case SDL_WINDOWEVENT_RESIZED: {
-          player_example_display_frame(player);
+	  player_example_display_frame(player);
           break;
         }
         default: break;


### PR DESCRIPTION
This fixes issue116 and explicitly maintains the aspect ratio in the fullscreen, independent of however the SDL_WINDOW_FULLSCREEN works.

If the other pull request from me has been merged then this one can be rejected I guess.

In addition to changing the SDL flag, I added a few lines of code, that explicitly adjust the *new* aspect ratio, based on the original aspect ratio.

Although, in my honest opinion, this is a bit of an overkill. I think the other pull request is sufficient.

Still, I compiled and tested both solutions and then seemed to work within reason.