### PR TITLE
Removing extra break; statement

### DIFF
--- a/tools/yuv2yuv4mpeg.c
+++ b/tools/yuv2yuv4mpeg.c
@@ -276,7 +276,6 @@ int main(int _argc,char *_argv[]){
     default:{
       fprintf(stderr,"Unsupported bit depth.\n");
       return -1;
-      break;
     }
   }
   fprintf(out_y4m,"\n");


### PR DESCRIPTION
Fix Issue : #220 
Removing the break ; statement 
there is no use of it 
when program reach the return statement if come out of that function 
so, it is never going to reach the break ; statement