### PR TITLE
Fix error in reading y4m

### DIFF
--- a/tools/y4m_input.c
+++ b/tools/y4m_input.c
@@ -560,14 +560,15 @@ static void y4m_convert_null(y4m_input *_y4m,unsigned char *_dst,
   (void)_dst;
   (void)_aux;
 }
+#define Y4M_HEADER_BUFSIZE 256
 
 static int y4m_input_open_impl(y4m_input *_y4m,FILE *_fin){
-  char buffer[80];
+  char buffer[Y4M_HEADER_BUFSIZE];
   int  ret;
   int  i;
   int  xstride;
   /*Read until newline, or 80 cols, whichever happens first.*/
-  for(i=0;i<79;i++){
+  for(i=0;i<Y4M_HEADER_BUFSIZE-1;i++){
     ret=fread(buffer+i,1,1,_fin);
     if(ret<1)return -1;
     if(buffer[i]=='\n')break;


### PR DESCRIPTION
Fix for issue https://github.com/xiph/daala/issues/232. Modifies maximum buffer size for y4m headers. Latest versions of ffmpeg allow more than 80 characters in the header for y4m files.